### PR TITLE
README: add note about subject prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,5 @@ Signed-off-by: Random J Developer <random@developer.example.org>
 description (Git can do this for you when you use `git commit -s`).
 Then send your patches to <oss-tools@pengutronix.de>, or, if you use GitHub,
 open a pull-request on <https://github.com/pengutronix/microcom>.
+If you send patches, please prefix your subject with "[PATCH microcom]" (for
+example, see the `git-config` manpage for the option `format.subjectPrefix`).


### PR DESCRIPTION
Since the mailing list is shared for various of our tools, the additional prefix helps to keep patches separated for the projects they should be applied to.