### PR TITLE
serial: configure CLOCAL/CREAD for non-Linux compatibility

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -34,7 +34,7 @@ static void init_comm(struct termios *pts)
 	/* some things we want to set arbitrarily */
 	pts->c_lflag &= ~ICANON;
 	pts->c_lflag &= ~(ECHO | ECHOCTL | ECHONL);
-	pts->c_cflag |= HUPCL;
+	pts->c_cflag |= HUPCL | CREAD | CLOCAL;
 	pts->c_iflag |= IGNBRK;
 	pts->c_cc[VMIN] = 1;
 	pts->c_cc[VTIME] = 0;


### PR DESCRIPTION
While [Linux configures both `CLOCAL` and `CREAD` on UARTs by default](https://github.com/torvalds/linux/blob/v4.20/drivers/tty/serial/serial_core.c#L2513),
other *nix systems might not.
E.g. macOS only sets `CREAD`, but not `CLOCAL` with the result that
`write(2)` indefinitely returns with `errno = EAGAIN`, waiting for a DCD
activation that never happens.

Fix this by explicitly OR'ing `CLOCAL`. On Linux, this doesn't
matter, but on macOS, it enables microcom to output user input.

`CREAD` is added as well to account for systems that don't set it by
default. This is in-line with what Michael R. Sweet's
"Serial Programming Guide for POSIX Operating Systems" [suggests](https://www.cmrr.umn.edu/~strupp/serial.html).

Patch tested on macOS 10.14.1 and Linux 4.20.13.

Signed-off-by: Ahmad Fatoum &lt;a.fatoum@pengutronix.de&gt;