### PR TITLE
lgtm: Add a config file to ensure autoconf-archive is available

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,5 @@
+extraction:
+    cpp:
+        prepare:
+            packages:
+                - autoconf-archive


### PR DESCRIPTION
See https://github.com/pengutronix/microcom/issues/8 for a report of
the actual problem.

Signed-off-by: Uwe Kleine-König <u.kleine-koenig@pengutronix.de>