### PR TITLE
Only handle IAC for telnet connections

### DIFF
--- a/can.c
+++ b/can.c
@@ -158,6 +158,7 @@ struct ios_ops *can_init(char *interface_id)
 	ios->set_flow = can_set_flow;
 	ios->send_break = can_send_break;
 	ios->exit = can_exit;
+	ios->istelnet = false;
 
 	/*
 	 * the string is supposed to be formated this way:

--- a/microcom.h
+++ b/microcom.h
@@ -26,6 +26,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <signal.h>
 #include <string.h>
 #include <termios.h>
@@ -48,6 +49,7 @@ struct ios_ops {
 	int (*set_handshake_line)(struct ios_ops *, int pin, int enable);
 	int (*send_break)(struct ios_ops *);
 	void (*exit)(struct ios_ops *);
+	bool istelnet;
 	int fd;
 };
 

--- a/mux.c
+++ b/mux.c
@@ -308,17 +308,6 @@ static int handle_receive_buf(struct ios_ops *ios, unsigned char *buf, int len)
 
 	while (len) {
 		switch (*buf) {
-		case IAC:
-			/* BUG: this is telnet specific */
-			write_receive_buf(sendbuf, buf - sendbuf);
-			i = handle_command(ios, buf, len);
-			if (i < 0)
-				return i;
-
-			buf += i;
-			len -= i;
-			sendbuf = buf;
-			break;
 		case 5:
 			write_receive_buf(sendbuf, buf - sendbuf);
 			if (answerback)
@@ -330,6 +319,19 @@ static int handle_receive_buf(struct ios_ops *ios, unsigned char *buf, int len)
 			len -= 1;
 			sendbuf = buf;
 			break;
+		case IAC:
+			if (ios->istelnet) {
+				write_receive_buf(sendbuf, buf - sendbuf);
+				i = handle_command(ios, buf, len);
+				if (i < 0)
+					return i;
+
+				buf += i;
+				len -= i;
+				sendbuf = buf;
+				break;
+			}
+			/* fall through */
 		default:
 			buf += 1;
 			len -= 1;

--- a/serial.c
+++ b/serial.c
@@ -163,6 +163,7 @@ struct ios_ops * serial_init(char *device)
 	ops->set_handshake_line = serial_set_handshake_line;
 	ops->send_break = serial_send_break;
 	ops->exit = serial_exit;
+	ops->istelnet = false;
 
 	/* check lockfile */
 	substring = strrchr(device, '/');

--- a/telnet.c
+++ b/telnet.c
@@ -96,6 +96,7 @@ struct ios_ops *telnet_init(char *hostport)
 	ios->set_flow = telnet_set_flow;
 	ios->send_break = telnet_send_break;
 	ios->exit = telnet_exit;
+	ios->istelnet = true;
 
 	memset(&hints, '\0', sizeof(hints));
 	hints.ai_flags = AI_ADDRCONFIG;


### PR DESCRIPTION
This is a bit ugly because the muxer should not be aware of telnet protocol
specifics but it is aware already anyhow, so we can just as well expand it
a bit.

Fixes: https://github.com/pengutronix/microcom/issues/4
Signed-off-by: Uwe Kleine-König <u.kleine-koenig@pengutronix.de>