### PR TITLE
Fix some UB in signal handling

### DIFF
--- a/can.c
+++ b/can.c
@@ -101,7 +101,6 @@ static int can_send_break(struct ios_ops *ios)
 static void can_exit(struct ios_ops *ios)
 {
 	close(ios->fd);
-	free(ios);
 }
 
 struct ios_ops *can_init(char *interface_id)

--- a/commands.c
+++ b/commands.c
@@ -150,6 +150,7 @@ static int cmd_break(int argc, char *argv[])
 static int cmd_quit(int argc, char *argv[])
 {
 	microcom_exit(0);
+	exit(0);
 	return 0;
 }
 

--- a/commands.c
+++ b/commands.c
@@ -149,6 +149,7 @@ static int cmd_break(int argc, char *argv[])
 
 static int cmd_quit(int argc, char *argv[])
 {
+	fflush(NULL);
 	microcom_exit(0);
 	exit(0);
 	return 0;

--- a/microcom.c
+++ b/microcom.c
@@ -122,7 +122,7 @@ char escape_char = DEFAULT_ESCAPE_CHAR;
 
 int main(int argc, char *argv[])
 {
-	struct sigaction sact;  /* used to initialize the signal handler */
+	struct sigaction sact = {0};  /* used to initialize the signal handler */
 	int opt, ret;
 	char *hostport = NULL;
 	int telnet = 0, can = 0;

--- a/microcom.c
+++ b/microcom.c
@@ -72,7 +72,8 @@ void microcom_exit(int signal)
 	ios->exit(ios);
 	tcsetattr(STDIN_FILENO, TCSANOW, &sots);
 
-	exit(0);
+	if (signal)
+		exit(0);
 }
 
 /********************************************************************

--- a/microcom.c
+++ b/microcom.c
@@ -67,13 +67,13 @@ void restore_terminal(void)
 
 void microcom_exit(int signal)
 {
-	printf("exiting\n");
+	write(1, "exiting\n", 8);
 
 	ios->exit(ios);
 	tcsetattr(STDIN_FILENO, TCSANOW, &sots);
 
 	if (signal)
-		exit(0);
+		_Exit(0);
 }
 
 /********************************************************************

--- a/serial.c
+++ b/serial.c
@@ -225,7 +225,6 @@ static void serial_exit(struct ios_ops *ios)
 {
 	tcsetattr(ios->fd, TCSANOW, &pots);
 	close(ios->fd);
-	free(ios);
 }
 
 struct ios_ops * serial_init(char *device)

--- a/telnet.c
+++ b/telnet.c
@@ -523,7 +523,6 @@ static int telnet_send_break(struct ios_ops *ios)
 static void telnet_exit(struct ios_ops *ios)
 {
 	close(ios->fd);
-	free(ios);
 }
 
 struct ios_ops *telnet_init(char *hostport)


### PR DESCRIPTION
While looking over #15, I noticed some issues with the way microcom handles signals. This fixes what was straight forward to fix. What remains is the access to `ios`, `ios->exit` and  whatever is called there. With #15 merged, this could be fixed by peppering some `volatile` around, but it's very unlikely to happen so postponing this for now.