### PR TITLE
parser: rename stdin variable to avoid collision with libc

### DIFF
--- a/parser.c
+++ b/parser.c
@@ -190,7 +190,7 @@ int do_commandline(void)
 int do_script(char *script)
 {
 	int fd = open(script, O_RDONLY);
-	int stdin = dup(1);
+	int stdinfd = dup(1);
 	int ret;
 
 	if (fd < 0) {
@@ -200,7 +200,7 @@ int do_script(char *script)
 
 	dup2(fd, 0);
 	ret = __do_commandline(NULL);
-	dup2(stdin, 0);
+	dup2(stdinfd, 0);
 
 	return ret;
 }


### PR DESCRIPTION
stdin as an identifier is reserved for the C implementation and indeed
on cygwin, it seems to cause microcom to fail to compile.
Fix this by renaming the variable.

Fixes: #16
`Signed-off-by: Ahmad Fatoum <ahmad@a3f.at>`