### PR TITLE
Allow logging to process

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -184,7 +184,7 @@ static int cmd_log(int argc, char *argv[])
 	if (argc < 2)
 		return MICROCOM_CMD_USAGE;
 
-	ret = logfile_open(argv[1]);
+	ret = log_open(argv);
 
 	return ret;
 }
@@ -239,7 +239,7 @@ static struct cmd cmds[] = {
 	}, {
 		.name = "log",
 		.fn = cmd_log,
-		.info = "log to file",
+		.info = "log to file or |executable",
 		.help = "log <logfile>",
 	}, {
 		.name = "#",

--- a/commands_fsl_imx.c
+++ b/commands_fsl_imx.c
@@ -384,7 +384,7 @@ static int upload_file(uint32_t address, char *name, unsigned char type)
 	};
 	struct stat stat;
 
-	upfd = open(name, O_RDONLY);
+	upfd = open(name, O_RDONLY | O_CLOEXEC);
 	if (upfd < 0) {
 		perror("open");
 		return 1;

--- a/microcom.1
+++ b/microcom.1
@@ -14,6 +14,8 @@ microcom \- A minimalistic terminal program
 .IR host : port ]
 .RB [\| \-s
 .IR speed \|]
+.RB [ -l
+.IR logfile ]
 .br
 .B microcom -c
 .IB interface : rx_id : tx_id
@@ -64,6 +66,11 @@ work in telnet (rfc2217) mode.
 .TP
 .BI \-c\  interface\fB:\fIrx_id\fB:\fItx_id\fR,\ \fI \-\-can= interface\fB:\fIrx_id\fB:\fItx_id
 work in CAN mode (default: \fBcan0:200:200\fR)
+.TP
+.BI \-l\  logfile \fR,\ \fB\-\-log= logfile
+log output to \fIlogfile\fR. If \fIlogfile\fR starts with a pipe `\fB|\fR' character,
+it's instead piped to an executable with that name in \fBPATH\fR. The executable receives
+the microcom output over \fBstdin\fR with \fBstdout\fR closed and \fBstderr\fR connected to microcom's \fBstderr\fR.
 .TP
 .BR -h ", " \-\-help
 Show help.

--- a/microcom.c
+++ b/microcom.c
@@ -182,7 +182,7 @@ void main_usage(int exitcode, char *str, char *dev)
 		"                                         default: (%s:%x:%x)\n"
 		"    -f, --force                          ignore existing lock file\n"
 		"    -d, --debug                          output debugging info\n"
-		"    -l, --logfile=<logfile>              log output to <logfile>\n"
+		"    -l, --logfile=<logfile>              log output to <logfile> or <|executable>\n"
 		"    -o, --listenonly                     Do not modify local terminal, do not send input\n"
 		"                                         from stdin\n"
 		"    -a,  --answerback=<str>              specify the answerback string sent as response to\n"
@@ -297,7 +297,12 @@ int main(int argc, char *argv[])
 		exit(1);
 
 	if (logfile) {
-		ret = logfile_open(logfile);
+		char *args[MAXARGS + 1];
+		ret = parse_line(logfile, NULL, args);
+		if (ret < 0)
+			exit(1);
+
+		ret = log_open(args);
 		if (ret < 0)
 			exit(1);
 	}
@@ -324,6 +329,8 @@ int main(int argc, char *argv[])
 		sigaction(SIGPIPE, &sact, NULL);
 		sigaction(SIGTERM, &sact, NULL);
 		sigaction(SIGQUIT, &sact, NULL);
+		sact.sa_handler = SIG_IGN;
+		sigaction(SIGCHLD, &sact, NULL);
 	}
 
 	/* run the main program loop */

--- a/microcom.h
+++ b/microcom.h
@@ -82,8 +82,12 @@ struct cmd {
 	char *help;
 };
 
-int logfile_open(const char *path);
-void logfile_close(void);
+#define MAXARGS 64
+
+int parse_line(char *_line, int *argc, char *argv[]);
+
+int log_open(char *argv[]);
+void log_close(void);
 
 int register_command(struct cmd *cmd);
 #define MICROCOM_CMD_START 100

--- a/mux.c
+++ b/mux.c
@@ -378,7 +378,7 @@ int logfile_open(const char *path)
 {
 	int fd;
 
-	fd = open(path, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+	fd = open(path, O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0644);
 	if (fd < 0) {
 		fprintf(stderr, "Cannot open logfile '%s': %s\n", path, strerror(errno));
 		return fd;

--- a/parser.c
+++ b/parser.c
@@ -11,9 +11,7 @@
 #include <readline/history.h>
 #include "microcom.h"
 
-#define MAXARGS 64
-
-static int parse_line(char *_line, int *argc, char *argv[])
+int parse_line(char *_line, int *argc, char *argv[])
 {
 	char *line = _line;
 	int nargs = 0;
@@ -64,7 +62,8 @@ static int parse_line(char *_line, int *argc, char *argv[])
         printf("Too many args (max. %d)\n", MAXARGS);
 out:
 	argv[nargs] = NULL;
-	*argc = nargs;
+	if (argc)
+		*argc = nargs;
 
 	return line - _line + 1;
 }

--- a/parser.c
+++ b/parser.c
@@ -189,7 +189,7 @@ int do_commandline(void)
 
 int do_script(char *script)
 {
-	int fd = open(script, O_RDONLY);
+	int fd = open(script, O_RDONLY | O_CLOEXEC);
 	int stdin = dup(1);
 	int ret;
 

--- a/serial.c
+++ b/serial.c
@@ -179,7 +179,7 @@ struct ios_ops * serial_init(char *device)
 	}
 
 relock:
-	fd = open(lockfile, O_RDWR | O_CREAT | O_EXCL, 0444);
+	fd = open(lockfile, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, 0444);
 	if (fd < 0) {
 		if (errno == EEXIST) {
 			char pidbuf[12];
@@ -227,7 +227,7 @@ relock:
 	close(fd);
 force:
 	/* open the device */
-	fd = open(device, O_RDWR | O_NONBLOCK);
+	fd = open(device, O_RDWR | O_NONBLOCK | O_CLOEXEC);
 	ops->fd = fd;
 
 	if (fd < 0) {

--- a/serial.c
+++ b/serial.c
@@ -200,9 +200,8 @@ relock:
 		main_usage(3, "cannot create lockfile", device);
 	}
 
-	/* Kermit wants binary pid */
 	pid = getpid();
-	write(fd, &pid, sizeof(long));
+	dprintf(fd, "%10ld\n", (long)pid);
 	close(fd);
 force:
 	/* open the device */


### PR DESCRIPTION
```
While microcom's stdout can be piped to another processes, it makes
input somewhat of a hassle. Address this by teaching the --logfile flag
and the log command that a filename starting with a pipe character refers
to an executable to start and pipe the input into. The child process shares
stderr, but has stdout closed.

Signed-off-by: Ahmad Fatoum <ahmad@a3f.at>
```

This pull request is rebased on top of #9 to avoid the merge conflict. I'll rebase when the other one is merged.