### PR TITLE
can: fix failing assertion and counter in CAN mode

### DIFF
--- a/can.c
+++ b/can.c
@@ -60,10 +60,10 @@ retry:
 		if (err < 0)
 			return err;
 
-		assert(err < count);
-		buf += err;
-		count -= err;
-		ret += err;
+		assert(err == sizeof(to_can));
+		buf += loopcount;
+		count -= loopcount;
+		ret += loopcount;
 	}
 
 	return ret;


### PR DESCRIPTION
This patch fixes the following assertion:

    microcom: can.c:63: can_write: Assertion `err < count' failed.

    #0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
    #1  0x00007ffff7db6535 in __GI_abort () at abort.c:79
    #2  0x00007ffff7db640f in __assert_fail_base (fmt=0x7ffff7f18ee0 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", assertion=0x55555555c3f3 "err < count", file=0x55555555c3d3 "can.c", line=63, function=<optimized out>) at assert.c:92
    #3  0x00007ffff7dc4102 in __GI___assert_fail (assertion=assertion@entry=0x55555555c3f3 "err < count", file=file@entry=0x55555555c3d3 "can.c", line=line@entry=63, function=function@entry=0x55555555c440 <__PRETTY_FUNCTION__.4646> "can_write") at assert.c:101
    #4  0x0000555555559cff in can_write (ios=0x555555560260, buf=0x7fffffffdb30, count=1) at can.c:63
    #5  can_write (ios=0x555555560260, buf=0x7fffffffdb30, count=1) at can.c:42
    #6  0x00005555555584d9 in cook_buf (num=1, buf=0x7fffffffdb30 "t", ios=<optimized out>) at mux.c:390
    #7  mux_loop (ios=0x555555560260) at mux.c:479
    #8  0x00005555555565e2 in main (argc=3, argv=0x7fffffffe2c8) at microcom.c:330

The write call returns the size of the whole CAN frame, which is
sizeof(struct can_frame), regardless of the length of the data. Use this
in the assertion.

For the same reason, we have to use struct can_frame::can_dlc as the
couter of sent bytes. This patch also fixes that problem.

Fixes: dc0d7aad38f2 ("can: Get rid of pthread for can transfers")
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>