### PR TITLE
add a `paste` command to write a local file to the terminal

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -145,6 +145,38 @@ static int cmd_break(int argc, char *argv[])
 	return MICROCOM_CMD_START;
 }
 
+static int cmd_paste(int argc, char *argv[])
+{
+	int fd = -1;
+	int i = 1;
+	int ret;
+	unsigned char buf[BUFSIZE];
+
+	if (argc < 2)
+		return MICROCOM_CMD_USAGE;
+
+	fd = open(argv[1], O_RDONLY);
+	if (fd == -1) {
+		ret = errno;
+		fprintf(stderr, "unable to open '%s': %s\n", argv[1], strerror(ret));
+		return -ret;
+	}
+
+	while (i > 0) {
+		i = read(fd, buf, BUFSIZE);
+		if (i < 0) {
+			ret = errno;
+			fprintf(stderr, "%s\n", strerror(ret));
+			return -ret;
+		}
+
+		ios->write(ios, buf, i);
+	}
+
+	close(fd);
+	return MICROCOM_CMD_START;
+}
+
 static int cmd_quit(int argc, char *argv[])
 {
 	microcom_exit(0);
@@ -223,6 +255,11 @@ static struct cmd cmds[] = {
 		.name = "break",
 		.fn = cmd_break,
 		.info = "send break",
+	}, {
+		.name = "paste",
+		.fn = cmd_paste,
+		.info = "write contents of file to the terminal",
+		.help = "paste <file>",
 	}, {
 		.name = "quit",
 		.fn = cmd_quit,

--- a/commands.c
+++ b/commands.c
@@ -234,7 +234,7 @@ static struct cmd cmds[] = {
 	}, {
 		.name = "x",
 		.fn = cmd_execute,
-		.info = "execute a script",
+		.info = "execute a script containing microcom commands",
 		.help = "x <scriptfile>",
 	}, {
 		.name = "log",

--- a/microcom.h
+++ b/microcom.h
@@ -55,6 +55,8 @@ struct ios_ops {
 	int fd;
 };
 
+#define BUFSIZE 1024
+
 int mux_loop(struct ios_ops *); /* mux.c */
 void init_terminal(void);
 void restore_terminal(void);

--- a/mux.c
+++ b/mux.c
@@ -23,8 +23,6 @@
 #include <stdarg.h>
 #include <stdbool.h>
 
-#define BUFSIZE 1024
-
 /* This is called with buf[-2:0] being IAC SB COM_PORT_OPTION */
 static int do_com_port_option(struct ios_ops *ios, unsigned char *buf, int len)
 {


### PR DESCRIPTION
This command can be useful as replacement for the clipboard, e.g. when working remotely over SSH, and when file transfer to the target is not available otherwise.

Usage example (`glados` is my host machine, `RPi3` is the target, non-printable key presses in angle brackets):

```
rohieb@glados:~ $ cat apparmor-profile
#include <tunables/global>
profile /usr/bin/rauc {
  #include <abstractions/base>
  
  capability sys_rawio,

  /usr/bin/rauc mr,
  /usr/bin/barebox-state cx,
  /usr/sbin/unsquashfs cx,
  /usr/bin/busybox.nosuid cx,
  /run/rauc/bundle/hook.sh Ux,
  /tmp/** rw,
  /mnt/updatebundle.rauc rk,
  /etc/rauc/* r,
  /proc/cmdline r, 
  /proc/*/fd/ r,
  /proc/*/mountinfo r,
  /run/rauc/** rw,
  /dev/mmcblk* rw,
  /sys/devices/**/mmcblk*/mmcblk*boot*/force_ro rw,
  /etc/ssl/openssl.cnf r,
}
  
rohieb@glados:~ $ microcom  -s 115200 /dev/ttyUSB0
root@RPi3:~ cat /usr/share/apparmor/usr.bin.rauc
cat: can't open '/usr/share/apparmor/usr.bin.rauc': No such file or directory
root@RPi3:~ cat > /usr/share/apparmor/usr.bin.rauc
<Ctrl-\>
Enter command. Try 'help' for a list of builtin commands
-> paste apparmor-profile

----------------------
#include <tunables/global>
profile /usr/bin/rauc flags=(attach_disconnected) {
  #include <abstractions/base>
  
  capability sys_rawio,
           
  /usr/bin/rauc mr,
  /usr/bin/barebox-state cx,
  /usr/sbin/unsquashfs cx,
  /usr/bin/busybox.nosuid cx,
  /run/rauc/bundle/hook.sh Ux,
  /tmp/** rw,
  /mnt/updatebundle.rauc rk,
  /etc/rauc/* r,
  /proc/cmdline r, 
  /proc/*/fd/ r,
  /proc/*/mountinfo r,
  /run/rauc/** rw,
  /dev/mmcblk* rw,
  /sys/devices/**/mmcblk*/mmcblk*boot*/force_ro rw,
  /etc/ssl/openssl.cnf r,
}
<Ctrl-D>
root@RPi3:~ ls -l /usr/share/apparmor/usr.bin.rauc
-rw-r--r--    1 root     root           521 Sep  1 00:12 /usr/share/apparmor/usr.bin.rauc
```
