### PR TITLE
Rework locking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,11 @@ AS_IF([test "x$enable_can" = "xyes"],
 
 AM_CONDITIONAL([CAN], [test "x$enable_can" = "xyes"])
 
+AC_ARG_ENABLE([file-locking], [AS_HELP_STRING([--enable-file-locking], [enable usage of lockfiles in /var/lock @<:@default=yes@:>@])],, [enable_file_locking=yes])
+
+AS_IF([test "x$enable_file_locking" = "xyes"],
+      [AC_DEFINE([USE_FILE_LOCKING], [1], [Define if file locking in /var/lock should be used])])
+
 AC_CONFIG_FILES([Makefile])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -15,7 +15,7 @@ AC_SYS_LARGEFILE
 AC_CHECK_LIB([readline], [readline])
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stdint.h stdlib.h string.h sys/ioctl.h sys/socket.h sys/time.h termios.h unistd.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stdint.h stdlib.h string.h sys/file.h sys/ioctl.h sys/socket.h sys/time.h termios.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T

--- a/microcom.h
+++ b/microcom.h
@@ -35,6 +35,8 @@
 #include <unistd.h>
 #include <assert.h>
 
+#include "config.h"
+
 #define DEFAULT_BAUDRATE 115200
 #define DEFAULT_DEVICE "/dev/ttyS0"
 #define DEFAULT_CAN_INTERFACE "can0"

--- a/microcom.h
+++ b/microcom.h
@@ -20,6 +20,7 @@
 ****************************************************************************/
 #ifndef MICROCOM_H
 #define MICROCOM_H
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <errno.h>

--- a/microcom.h
+++ b/microcom.h
@@ -20,6 +20,7 @@
 ****************************************************************************/
 #ifndef MICROCOM_H
 #define MICROCOM_H
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/serial.c
+++ b/serial.c
@@ -287,6 +287,13 @@ struct ios_ops * serial_init(char *device)
 		main_usage(2, "cannot open device", device);
 	}
 
+	ret = flock(fd, LOCK_EX | LOCK_NB);
+	if (ret < 0) {
+		if (!opt_force)
+			main_usage(3, "could not flock port", device);
+		printf("could not flock port, ignoring\n");
+	}
+
 	/* modify the port configuration */
 	tcgetattr(fd, &pts);
 	memcpy(&pots, &pts, sizeof (pots));


### PR DESCRIPTION
This provides a more conservative alternative to #28. Even if locking via `/var/lock/LCK..*` wasn't invented in this millenium, there are still some programs/libs that only implement this.

So here implement `flock()`ing additionally to the uucp-style locking. For Linux variants where `/var/lock` isn't writable, there is a `./configure' option to disable uucp-locking.

To make uucp-style locking a bit less annoying, only lockfiles are honored that contain a pid that is still runnable.