### PR TITLE
telnet: Don't send DO COM_PORT_CONTROL

### DIFF
--- a/telnet.c
+++ b/telnet.c
@@ -596,11 +596,9 @@ struct ios_ops *telnet_init(char *hostport)
 		}
 		printf("connected to %s (port %s)\n", connected_host, connected_port);
 
-		/* send intent to do and accept COM_PORT stuff */
+		/* send intent we WILL do COM_PORT stuff */
 		dbg_printf("-> WILL COM_PORT_CONTROL\n");
 		dprintf(sock, "%c%c%c", IAC, WILL, TELNET_OPTION_COM_PORT_CONTROL);
-		dbg_printf("-> DO COM_PORT_CONTROL\n");
-		dprintf(sock, "%c%c%c", IAC, DO, TELNET_OPTION_COM_PORT_CONTROL);
 		goto out;
 	}
 


### PR DESCRIPTION
That request isn't sensible because microcom doesn't implement to be an UART access server.

Both ser2net and Moxa UART servers reply with WONT COM_PORT_CONTROL to a DO, so the request is refused. To actually use the COM_PORT_CONTROL extension only a "client side" WILL (by microcom) and a "server side" DO (by the remote side) is necessary (and sensible).

The rfc2217 document also reads:

    Typically a client will use WILL and WONT, while an access server
    will use DO and DONT.