### PR TITLE
microcom: allow for specifying the escape character

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -155,7 +155,8 @@ static int cmd_quit(int argc, char *argv[])
 
 static int cmd_sendescape(int argc, char *argv[])
 {
-	ios->write(ios, "\x1c", 1);
+	unsigned char tmp = CTRL(escape_char);
+	ios->write(ios, &tmp, 1);
 	return 0;
 }
 
@@ -234,7 +235,7 @@ static struct cmd cmds[] = {
 	}, {
 		.name = "sendescape",
 		.fn = cmd_sendescape,
-		.info = "send a Ctrl-\\",
+		.info = "send the escape sequence",
 	}, {
 		.name = "quit",
 		.fn = cmd_quit,

--- a/microcom.1
+++ b/microcom.1
@@ -14,6 +14,8 @@ microcom \- A minimalistic terminal program
 .IR host : port ]
 .RB [\| \-s
 .IR speed \|]
+.RB [\| \-e
+.IR escape-char \|]
 .br
 .B microcom -c
 .IB interface : rx_id : tx_id
@@ -64,6 +66,9 @@ work in telnet (rfc2217) mode.
 .TP
 .BI \-c\  interface\fB:\fIrx_id\fB:\fItx_id\fR,\ \fI \-\-can= interface\fB:\fIrx_id\fB:\fItx_id
 work in CAN mode (default: \fBcan0:200:200\fR)
+.TP
+.BI \-e\  escape-character \fR,\ \fB\-\-escape-char= char
+use specified escape charater with Ctrl (default \fB\\\fR).
 .TP
 .BR -h ", " \-\-help
 Show help.

--- a/microcom.c
+++ b/microcom.c
@@ -101,12 +101,14 @@ void main_usage(int exitcode, char *str, char *dev)
 		"    -l, --logfile=<logfile>              log output to <logfile>\n"
 		"    -o, --listenonly                     Do not modify local terminal, do not send input\n"
 		"                                         from stdin\n"
-		"    -a,  --answerback=<str>              specify the answerback string sent as response to\n"
+		"    -a, --answerback=<str>               specify the answerback string sent as response to\n"
 		"                                         an ENQ (ASCII 0x05) Character\n"
+		"    -e, --escape-char=<chr>              escape charater to use with Ctrl (%c)\n"
 		"    -v, --version                        print version string\n"
 		"    -h, --help                           This help\n",
 		DEFAULT_DEVICE, DEFAULT_BAUDRATE,
-		DEFAULT_CAN_INTERFACE, DEFAULT_CAN_ID, DEFAULT_CAN_ID);
+		DEFAULT_CAN_INTERFACE, DEFAULT_CAN_ID, DEFAULT_CAN_ID,
+		DEFAULT_ESCAPE_CHAR);
 	fprintf(stderr, "Exitcode %d - %s %s\n\n", exitcode, str, dev);
 	exit(exitcode);
 }
@@ -115,6 +117,7 @@ int opt_force = 0;
 unsigned long current_speed = DEFAULT_BAUDRATE;
 int current_flow = FLOW_NONE;
 int listenonly = 0;
+char escape_char = DEFAULT_ESCAPE_CHAR;
 
 int main(int argc, char *argv[])
 {
@@ -141,7 +144,7 @@ int main(int argc, char *argv[])
 		{ },
 	};
 
-	while ((opt = getopt_long(argc, argv, "hp:s:t:c:dfl:oi:a:v", long_options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hp:s:t:c:dfl:oi:a:e:v", long_options, NULL)) != -1) {
 		switch (opt) {
 			case '?':
 				main_usage(1, "", "");
@@ -181,6 +184,13 @@ int main(int argc, char *argv[])
 				break;
 			case 'a':
 				answerback = optarg;
+				break;
+			case 'e':
+				if (strlen(optarg) != 1) {
+					fprintf(stderr, "Option -e requires a single character argument.\n");
+					exit(EXIT_FAILURE);
+				}
+				escape_char = *optarg;
 				break;
 		}
 	}
@@ -229,7 +239,7 @@ int main(int argc, char *argv[])
 	ios->set_flow(ios, current_flow);
 
 	if (!listenonly) {
-		printf("Escape character: Ctrl-\\\n");
+		printf("Escape character: Ctrl-%c\n", escape_char);
 		printf("Type the escape character to get to the prompt.\n");
 
 		/* Now deal with the local terminal side */

--- a/microcom.h
+++ b/microcom.h
@@ -29,6 +29,7 @@
 #include <stdbool.h>
 #include <signal.h>
 #include <string.h>
+#include <sys/ttydefaults.h>
 #include <termios.h>
 #include <unistd.h>
 #include <assert.h>
@@ -37,6 +38,7 @@
 #define DEFAULT_DEVICE "/dev/ttyS0"
 #define DEFAULT_CAN_INTERFACE "can0"
 #define DEFAULT_CAN_ID (0x200)
+#define DEFAULT_ESCAPE_CHAR ('\\')
 
 struct ios_ops {
 	ssize_t (*write)(struct ios_ops *, const void *buf, size_t count);
@@ -73,6 +75,7 @@ extern int debug;
 extern int opt_force;
 extern int listenonly;
 extern char *answerback;
+extern char escape_char;
 
 struct cmd {
 	char *name;

--- a/mux.c
+++ b/mux.c
@@ -73,7 +73,7 @@ static void cook_buf(struct ios_ops *ios, unsigned char *buf, int num)
 	while (current < num) {	/* big while loop, to process all the charactes in buffer */
 
 		/* look for the next escape character (Ctrl-\) */
-		while ((current < num) && (buf[current] != 28))
+		while ((current < num) && (buf[current] != CTRL(escape_char)))
 			current++;
 		/* and write the sequence before esc char to the comm port */
 		if (current)


### PR DESCRIPTION
This allows for choosing the escape character freely.

The motivation for me is to make `microcom` a bit more Emacs friendly: now I can specify, e.g. `Ctrl-]` for being my escape sequence which does not have a special meaning like `Ctrl-\` in Emacs.