### PR TITLE
main: error out on positional arguments

### DIFF
--- a/microcom.c
+++ b/microcom.c
@@ -183,6 +183,9 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	if (optind < argc)
+		main_usage(1, "", "");
+
 	if (answerback) {
 		ret = asprintf(&answerback, "%s\n", answerback);
 		if (ret < 0)


### PR DESCRIPTION
As microcom makes no use of positional arguments, error out and show usage if a positional argument is presented.

Without this patch, invalid usage involving a positional such as `microcom /dev/ttyUSB0` is silently ignored.