### PR TITLE
can.c: Remove EINTR handling

### DIFF
--- a/can.c
+++ b/can.c
@@ -53,10 +53,7 @@ static ssize_t can_write(struct ios_ops *ios, const void *buf, size_t count)
 		loopcount = min(count, sizeof(to_can.data));
 		memcpy(to_can.data, buf, loopcount);
 		to_can.can_dlc = loopcount;
-retry:
 		err = write(ios->fd, &to_can, sizeof(to_can));
-		if (err < 0 && errno == EINTR)
-			goto retry;
 
 		if (err < 0)
 			return err;
@@ -75,10 +72,7 @@ static ssize_t can_read(struct ios_ops *ios, void *buf, size_t count)
 	struct can_frame from_can;
 	ssize_t ret;
 
-retry:
 	ret = read(ios->fd, &from_can, sizeof(from_can));
-	if (ret < 0 && errno != EINTR)
-		goto retry;
 
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
read() and write() can return EINTR if a signal handler ran while polling in a driver before transferring any data.

While it is idiomatic to retry the transfer in such a case, the only signal handler used by microcom, microcom_exit, always exits, so there is no need to handle EINTR.

resolves https://github.com/pengutronix/microcom/issues/21