### PR TITLE
Copy tty settings for stdin from minicom

### DIFF
--- a/microcom.c
+++ b/microcom.c
@@ -43,15 +43,17 @@ void init_terminal(void)
 
 	memcpy(&sts, &sots, sizeof (sots));     /* to be used upon exit */
 
-	/* again, some arbitrary things */
-	sts.c_iflag &= ~(IGNCR | INLCR | ICRNL);
-	sts.c_iflag |= IGNBRK;
-	sts.c_lflag &= ~ISIG;
+	/* Implement what `stty raw` does. */
+	sts.c_iflag &= ~(IGNBRK | BRKINT | IGNPAR | PARMRK | INPCK |
+			 ISTRIP | INLCR | IGNCR | ICRNL | IXON | IXOFF |
+			 IUCLC | IXANY | IMAXBEL);
+	sts.c_lflag &= ~(ICANON | ISIG | XCASE);
+	sts.c_oflag &= ~OPOST;
 	sts.c_cc[VMIN] = 1;
 	sts.c_cc[VTIME] = 0;
-	sts.c_lflag &= ~ICANON;
+
 	/* no local echo: allow the other end to do the echoing */
-	sts.c_lflag &= ~(ECHO | ECHOCTL | ECHONL);
+	sts.c_lflag &= ~ECHO;
 
 	tcsetattr(STDIN_FILENO, TCSANOW, &sts);
 }


### PR DESCRIPTION
I didn't try to understand all the details, but with these settings driving the Debian installer works (while with the previous configuration it didn't).

With the previous settings the usual look of the terminal is as follows (and worse):
![installer](https://github.com/user-attachments/assets/2d2dfa6b-cab7-4e8d-a62c-2809d488b948)

With the new settings I didn't find a broken menu yet.