### PR TITLE
microcom.1: Fix a typo

### DIFF
--- a/microcom.1
+++ b/microcom.1
@@ -68,7 +68,7 @@ work in telnet (rfc2217) mode.
 work in CAN mode (default: \fBcan0:200:200\fR)
 .TP
 .BI \-e\  escape-character \fR,\ \fB\-\-escape-char= char
-use specified escape charater with Ctrl (default \fB\\\fR).
+use specified escape character with Ctrl (default \fB\\\fR).
 .TP
 .BR -h ", " \-\-help
 Show help.


### PR DESCRIPTION
Noticed by lintian.

Fixes: 8e6af30e81f7 ("microcom: allow for specifying the escape character")