### PR TITLE
General code cleanup

### DIFF
--- a/can.c
+++ b/can.c
@@ -1,19 +1,5 @@
-/*
- * Description: the can part for microcom project
- *
- * Copyright (C) 2010 by Marc Kleine-Budde <mkl@pengutronix.de>
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details at www.gnu.org
- *
- */
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 2010 Marc Kleine-Budde <mkl@pengutronix.de>
 #include "config.h"
 
 #include <stdlib.h>

--- a/can.c
+++ b/can.c
@@ -40,7 +40,7 @@ struct can_data {
 
 static struct can_data data;
 
-static ssize_t can_write(struct ios_ops *ios, const void *buf, size_t count)
+static ssize_t can_write(struct ios_ops *ios, const unsigned char *buf, size_t count)
 {
 	size_t loopcount;
 	ssize_t ret = 0, err;
@@ -67,7 +67,7 @@ static ssize_t can_write(struct ios_ops *ios, const void *buf, size_t count)
 	return ret;
 }
 
-static ssize_t can_read(struct ios_ops *ios, void *buf, size_t count)
+static ssize_t can_read(struct ios_ops *ios, unsigned char *buf, size_t count)
 {
 	struct can_frame from_can;
 	ssize_t ret;

--- a/commands.c
+++ b/commands.c
@@ -1,11 +1,5 @@
-/*
- * Copyright (C) 2010 Sascha Hauer <s.hauer@pengutronix.de>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- */
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 2010 Sascha Hauer <s.hauer@pengutronix.de>
 #include "config.h"
 
 #include <stdlib.h>

--- a/commands.c
+++ b/commands.c
@@ -152,6 +152,7 @@ static int cmd_quit(int argc, char *argv[])
 static int cmd_sendescape(int argc, char *argv[])
 {
 	unsigned char tmp = CTRL(escape_char);
+
 	ios->write(ios, &tmp, 1);
 	return 0;
 }

--- a/commands_fsl_imx.c
+++ b/commands_fsl_imx.c
@@ -512,8 +512,9 @@ static void fsl_sniff_memwrite(void)
 	uint32_t addr, val;
 
 	printf("mw ");
-	for (i = 0; i < 15; i++) {
-		read(ios->fd, &buf[i], 1);
+	if (read(ios->fd, buf, 15) < 15) {
+		printf("read error\n");
+		return;
 	}
 
 	addr = (buf[1] << 24) | (buf[2] << 16) | (buf[3] << 8) | (buf[4] << 0);
@@ -528,7 +529,10 @@ static void fsl_sniff_6(void)
 
 	printf("cmd6\n");
 	for (i = 0; i < 15; i++) {
-		read(ios->fd, &buf[i], 1);
+		if (read(ios->fd, &buf[i], 1) != 1) {
+			printf("read error\n");
+			return;
+		}
 		printf("%02x ", buf[i]);
 	}
 	printf("\n");
@@ -541,7 +545,10 @@ static void fsl_sniff_sts(void)
 
 	printf("cmd get status\n");
 	for (i = 0; i < 15; i++) {
-		read(ios->fd, &buf[i], 1);
+		if (read(ios->fd, &buf[i], 1) != 1) {
+			printf("read error\n");
+			return;
+		}
 		printf("%02x ", buf[i]);
 	}
 	printf("\n");
@@ -560,8 +567,9 @@ static void fsl_sniff_upload(void)
 
 	printf("upload ");
 
-	for (i = 0; i < 15; i++) {
-		read(ios->fd, &buf[i], 1);
+	if (read(ios->fd, buf, 15) < 15) {
+		printf("read error\n");
+		return;
 	}
 	addr = (buf[1] << 24) | (buf[2] << 16) | (buf[3] << 8) | (buf[4] << 0);
 	size = (buf[6] << 24) | (buf[7] << 16) | (buf[8] << 8) | (buf[9] << 0);
@@ -582,7 +590,11 @@ static void fsl_sniff_upload(void)
 
 	for (i = 0; i < size; i++) {
 		unsigned char tmp;
-		read(ios->fd, &tmp, 1);
+
+		if (read(ios->fd, &tmp, 1) != 1) {
+			printf("read error\n");
+			return;
+		}
 		printf("%02x ", tmp);
 		if (!((i + 1) % 32))
 			printf("\n");
@@ -594,7 +606,10 @@ static int fsl_sniff(int argc, char *argv[])
 {
 	while (1) {
 		unsigned char cmd;
-		read(ios->fd, &cmd, 1);
+		if (read(ios->fd, &cmd, 1) != 1) {
+			printf("read error\n");
+			return 1;
+		}
 		switch (cmd) {
 		case 0x2:
 			fsl_sniff_memwrite();

--- a/commands_fsl_imx.c
+++ b/commands_fsl_imx.c
@@ -508,7 +508,6 @@ static int fsl_connect(int argc, char *argv[])
 static void fsl_sniff_memwrite(void)
 {
 	unsigned char buf[15];
-	int i;
 	uint32_t addr, val;
 
 	printf("mw ");

--- a/commands_fsl_imx.c
+++ b/commands_fsl_imx.c
@@ -45,7 +45,7 @@ static int get_ack(int fd)
 			return -1;
 		}
 		if (r != expect[i])
-			return -1;;
+			return -1;
 	}
 
 	return 0;
@@ -79,11 +79,11 @@ static int sync_com(int fd)
 
 static int read_mem(int fd, uint32_t address, void *_buf, int size, int accesssize)
 {
-	unsigned char buf[] = {0x1, 0x1,			/* read command */
-				0x0, 0x0, 0x0, 0x0,		/* address */
-				0x20,				/* data size */
-				0x0, 0x0, 0x0, 0x0,		/* count */
-				0x0, 0x0, 0x0, 0x0, 0x0};	/* fill */
+	unsigned char buf[] = { 0x1, 0x1,                        /* read command */
+				0x0, 0x0, 0x0, 0x0,              /* address */
+				0x20,                            /* data size */
+				0x0, 0x0, 0x0, 0x0,              /* count */
+				0x0, 0x0, 0x0, 0x0, 0x0 };       /* fill */
 	int i = 0, ret;
 	uint8_t *buf8 = _buf;
 	uint16_t *buf16 = _buf;
@@ -188,11 +188,11 @@ static int memory_display(char *addr, unsigned long offs, unsigned long nbytes, 
 	 * once, and all accesses are with the specified bus width.
 	 */
 	do {
-		char	linebuf[DISP_LINE_LEN];
-		uint	*uip = (uint   *)linebuf;
-		ushort	*usp = (ushort *)linebuf;
-		u_char	*ucp = (u_char *)linebuf;
-		uint	count = 52;
+		char linebuf[DISP_LINE_LEN];
+		uint   *uip = (uint   *)linebuf;
+		ushort *usp = (ushort *)linebuf;
+		u_char *ucp = (u_char *)linebuf;
+		uint count = 52;
 
 		printf("%08lx:", offs);
 		linebytes = (nbytes > DISP_LINE_LEN) ? DISP_LINE_LEN : nbytes;
@@ -209,7 +209,7 @@ static int memory_display(char *addr, unsigned long offs, unsigned long nbytes, 
 			offs += size;
 		}
 
-		while(count--)
+		while (count--)
 			printf(" ");
 
 		cp = (unsigned char *)linebuf;
@@ -255,14 +255,14 @@ out:
 
 static int write_mem(uint32_t address, uint32_t val, int accesssize)
 {
-	unsigned char buf[] = { 0x2, 0x2,	/* write command */
-		0x0, 0x0, 0x0, 0x0,		/* address */
-		0x0,				/* data size */
-		0x0, 0x0, 0x0, 0x0,		/* fill */
-		0x0, 0x0, 0x0, 0x0,		/* value */
-		0x0,				/* fill */
+	unsigned char buf[] = { 0x2, 0x2,           /* write command */
+				0x0, 0x0, 0x0, 0x0, /* address */
+				0x0,                /* data size */
+				0x0, 0x0, 0x0, 0x0, /* fill */
+				0x0, 0x0, 0x0, 0x0, /* value */
+				0x0,                /* fill */
 	};
-	unsigned char expect[] = {0x12, 0x8a, 0x8a, 0x12};
+	unsigned char expect[] = { 0x12, 0x8a, 0x8a, 0x12 };
 	int i, ret;
 	unsigned char r;
 
@@ -311,7 +311,7 @@ static int write_mem(uint32_t address, uint32_t val, int accesssize)
 			return -1;
 		}
 		if (r != expect[i])
-			return -1;;
+			return -1;
 	}
 
 	return 0;
@@ -351,6 +351,7 @@ static int do_header(uint32_t addr)
 		0x0, 0x0, 0x0, 0x0,
 		0x0, 0x0, 0x0, 0x0,
 	};
+
 	buf[0] = (addr >>  0) & 0xff;
 	buf[1] = (addr >>  8) & 0xff;
 	buf[2] = (addr >> 16) & 0xff;
@@ -371,12 +372,12 @@ static int upload_file(uint32_t address, char *name, unsigned char type)
 {
 	uint32_t size;
 	int upfd, ret, i;
-	unsigned char buf[] = { 0x4, 0x4,	/* upload command */
-		0x0, 0x0, 0x0, 0x0,		/* address */
-		0x0,				/* fill */
-		0x0, 0x0, 0x0, 0x0,		/* filesize */
-		0x0, 0x0, 0x0, 0x0,		/* fill */
-		0xaa,				/* filetype */
+	unsigned char buf[] = { 0x4, 0x4,           /* upload command */
+				0x0, 0x0, 0x0, 0x0, /* address */
+				0x0,                /* fill */
+				0x0, 0x0, 0x0, 0x0, /* filesize */
+				0x0, 0x0, 0x0, 0x0, /* fill */
+				0xaa,               /* filetype */
 	};
 	struct stat stat;
 
@@ -452,12 +453,11 @@ out:
 static int upload(int argc, char *argv[])
 {
 	uint32_t address;
-	unsigned char buf[] = { 0x5, 0x5,	/* status command */
-		0x0, 0x0, 0x0, 0x0,
-		0x0, 0x0, 0x0, 0x0,
-		0x0, 0x0, 0x0, 0x0,
-		0x0, 0x0,
-	};
+	unsigned char buf[] = { 0x5, 0x5,           /* status command */
+				0x0, 0x0, 0x0, 0x0,
+				0x0, 0x0, 0x0, 0x0,
+				0x0, 0x0, 0x0, 0x0,
+				0x0, 0x0, };
 	int i, ret, type = 0;
 
 	if (argc < 3)
@@ -511,7 +511,7 @@ static void fsl_sniff_memwrite(void)
 	}
 
 	addr = (buf[1] << 24) | (buf[2] << 16) | (buf[3] << 8) | (buf[4] << 0);
-	val = (buf[10] << 24)| (buf[11] << 16) | (buf[12] << 8) | (buf[13] << 0);
+	val = (buf[10] << 24) | (buf[11] << 16) | (buf[12] << 8) | (buf[13] << 0);
 	printf("0x%08x 0x%08x\n", addr, val);
 }
 
@@ -569,7 +569,7 @@ static void fsl_sniff_upload(void)
 
 	printf(" adr: 0x%08x size: 0x%08x type 0x%02x ", addr, size, buf[14]);
 
-	switch(buf[14]) {
+	switch (buf[14]) {
 	case 0xaa:
 		printf("(application)\n");
 		break;
@@ -622,7 +622,7 @@ static int fsl_sniff(int argc, char *argv[])
 		default:
 			printf("unknown cmd 0x%02x\n", cmd);
 			break;
-		};
+		}
 	}
 
 	return 0;

--- a/commands_fsl_imx.c
+++ b/commands_fsl_imx.c
@@ -1,11 +1,5 @@
-/*
- * Copyright (C) 2010 Sascha Hauer <s.hauer@pengutronix.de>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- */
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 2010 Sascha Hauer <s.hauer@pengutronix.de>
 #include "config.h"
 
 #include <stdio.h>

--- a/microcom.c
+++ b/microcom.c
@@ -1,24 +1,5 @@
-/******************************************************************
-** File: microcom.c
-** Description: the main file for microcom project
-**
-** Copyright (C)1999 Anca and Lucian Jurubita <ljurubita@hotmail.com>.
-** All rights reserved.
-****************************************************************************
-** This program is free software; you can redistribute it and/or
-** modify it under the terms of the GNU General Public License
-** as published by the Free Software Foundation; either version 2
-** of the License, or (at your option) any later version.
-**
-** This program is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-** GNU General Public License for more details at www.gnu.org
-****************************************************************************
-** Rev. 1.0 - Feb. 2000
-** Rev. 1.01 - March 2000
-** Rev. 1.02 - June 2000
-****************************************************************************/
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999 Anca and Lucian Jurubita <ljurubita@hotmail.com>.
 #define _GNU_SOURCE
 #include "microcom.h"
 

--- a/microcom.c
+++ b/microcom.c
@@ -14,7 +14,7 @@
 #include "config.h"
 #include "compat.h"
 
-static struct termios sots;	/* old stdout/in termios settings to restore */
+static struct termios sots; /* old stdout/in termios settings to restore */
 
 struct ios_ops *ios;
 int debug;
@@ -23,7 +23,7 @@ void init_terminal(void)
 {
 	struct termios sts;
 
-	memcpy(&sts, &sots, sizeof (sots));     /* to be used upon exit */
+	memcpy(&sts, &sots, sizeof(sots)); /* to be used upon exit */
 
 	/* Implement what `stty raw` does. */
 	sts.c_iflag &= ~(IGNBRK | BRKINT | IGNPAR | PARMRK | INPCK |
@@ -57,19 +57,19 @@ void microcom_exit(int signal)
 		_Exit(0);
 }
 
-/********************************************************************
- Main functions
+/*
+ * Main functions
  ********************************************************************
- static void help_usage(int exitcode, char *error, char *addl)
-      help with running the program
-      - exitcode - to be returned when the program is ended
-      - error - error string to be printed
-      - addl - another error string to be printed
- static void cleanup_termios(int signal)
-      signal handler to restore terminal set befor exit
- int main(int argc, char *argv[]) -
-      main program function
-********************************************************************/
+ * static void help_usage(int exitcode, char *error, char *addl)
+ *      help with running the program
+ *      - exitcode - to be returned when the program is ended
+ *      - error - error string to be printed
+ *      - addl - another error string to be printed
+ * static void cleanup_termios(int signal)
+ *      signal handler to restore terminal set befor exit
+ * int main(int argc, char *argv[]) -
+ *      main program function
+ */
 void main_usage(int exitcode, char *str, char *dev)
 {
 	fprintf(stderr, "Usage: microcom [options]\n"
@@ -114,67 +114,67 @@ int main(int argc, char *argv[])
 
 	struct option long_options[] = {
 		{ "help", no_argument, NULL, 'h' },
-		{ "port", required_argument, NULL, 'p'},
-		{ "speed", required_argument, NULL, 's'},
-		{ "telnet", required_argument, NULL, 't'},
-		{ "can", required_argument, NULL, 'c'},
+		{ "port", required_argument, NULL, 'p' },
+		{ "speed", required_argument, NULL, 's' },
+		{ "telnet", required_argument, NULL, 't' },
+		{ "can", required_argument, NULL, 'c' },
 		{ "debug", no_argument, NULL, 'd' },
 		{ "force", no_argument, NULL, 'f' },
-		{ "logfile", required_argument, NULL, 'l'},
-		{ "listenonly", no_argument, NULL, 'o'},
-		{ "answerback", required_argument, NULL, 'a'},
+		{ "logfile", required_argument, NULL, 'l' },
+		{ "listenonly", no_argument, NULL, 'o' },
+		{ "answerback", required_argument, NULL, 'a' },
 		{ "version", no_argument, NULL, 'v' },
 		{ 0 },
 	};
 
 	while ((opt = getopt_long(argc, argv, "hp:s:t:c:dfl:oi:a:e:v", long_options, NULL)) != -1) {
 		switch (opt) {
-			case '?':
-				main_usage(1, "", "");
-				break;
-			case 'h':
-				main_usage(0, "", "");
-				break;
-			case 'v':
-				printf("%s\n", PACKAGE_VERSION);
-				exit(EXIT_SUCCESS);
-				break;
-			case 'p':
-				device = optarg;
-				break;
-			case 's':
-				current_speed = strtoul(optarg, NULL, 0);
-				break;
-			case 't':
-				telnet = 1;
-				hostport = optarg;
-				break;
-			case 'c':
-				can = 1;
-				interfaceid = optarg;
-				break;
-			case 'f':
-				opt_force = 1;
-				break;
-			case 'd':
-				debug = 1;
-				break;
-			case 'l':
-				logfile = optarg;
-				break;
-			case 'o':
-				listenonly = 1;
-				break;
-			case 'a':
-				answerback = optarg;
-				break;
-			case 'e':
-				if (strlen(optarg) != 1) {
-					fprintf(stderr, "Option -e requires a single character argument.\n");
-					exit(EXIT_FAILURE);
-				}
-				escape_char = *optarg;
-				break;
+		case '?':
+			main_usage(1, "", "");
+			break;
+		case 'h':
+			main_usage(0, "", "");
+			break;
+		case 'v':
+			printf("%s\n", PACKAGE_VERSION);
+			exit(EXIT_SUCCESS);
+			break;
+		case 'p':
+			device = optarg;
+			break;
+		case 's':
+			current_speed = strtoul(optarg, NULL, 0);
+			break;
+		case 't':
+			telnet = 1;
+			hostport = optarg;
+			break;
+		case 'c':
+			can = 1;
+			interfaceid = optarg;
+			break;
+		case 'f':
+			opt_force = 1;
+			break;
+		case 'd':
+			debug = 1;
+			break;
+		case 'l':
+			logfile = optarg;
+			break;
+		case 'o':
+			listenonly = 1;
+			break;
+		case 'a':
+			answerback = optarg;
+			break;
+		case 'e':
+			if (strlen(optarg) != 1) {
+				fprintf(stderr, "Option -e requires a single character argument.\n");
+				exit(EXIT_FAILURE);
+			}
+			escape_char = *optarg;
+			break;
 		}
 	}
 
@@ -184,7 +184,7 @@ int main(int argc, char *argv[])
 	if (answerback) {
 		ret = asprintf(&answerback, "%s\n", answerback);
 		if (ret < 0)
-			exit (1);
+			exit(1);
 	}
 
 	commands_init();

--- a/microcom.c
+++ b/microcom.c
@@ -181,12 +181,6 @@ int main(int argc, char *argv[])
 	if (optind < argc)
 		main_usage(1, "", "");
 
-	if (answerback) {
-		ret = asprintf(&answerback, "%s\n", answerback);
-		if (ret < 0)
-			exit(1);
-	}
-
 	commands_init();
 	commands_fsl_imx_init();
 

--- a/microcom.c
+++ b/microcom.c
@@ -17,7 +17,7 @@
 static struct termios sots; /* old stdout/in termios settings to restore */
 
 struct ios_ops *ios;
-int debug;
+int debug = 0;
 
 void init_terminal(void)
 {

--- a/microcom.c
+++ b/microcom.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
 		{ "listenonly", no_argument, NULL, 'o'},
 		{ "answerback", required_argument, NULL, 'a'},
 		{ "version", no_argument, NULL, 'v' },
-		{ },
+		{ 0 },
 	};
 
 	while ((opt = getopt_long(argc, argv, "hp:s:t:c:dfl:oi:a:e:v", long_options, NULL)) != -1) {

--- a/microcom.h
+++ b/microcom.h
@@ -44,12 +44,12 @@ struct ios_ops {
 	ssize_t (*write)(struct ios_ops *, const unsigned char *buf, size_t count);
 	ssize_t (*read)(struct ios_ops *, unsigned char *buf, size_t count);
 	int (*set_speed)(struct ios_ops *, unsigned long speed);
-#define FLOW_NONE	0
-#define FLOW_SOFT	1
-#define FLOW_HARD	2
+#define FLOW_NONE       0
+#define FLOW_SOFT       1
+#define FLOW_HARD       2
 	int (*set_flow)(struct ios_ops *, int flow);
-#define PIN_DTR	1
-#define PIN_RTS	2
+#define PIN_DTR 1
+#define PIN_RTS 2
 	int (*set_handshake_line)(struct ios_ops *, int pin, int enable);
 	int (*send_break)(struct ios_ops *);
 	void (*exit)(struct ios_ops *);
@@ -79,7 +79,7 @@ extern char escape_char;
 
 struct cmd {
 	char *name;
-	int(*fn)(int argc, char *argv[]);
+	int (*fn)(int argc, char *argv[]);
 	struct cmd *next;
 	char *info;
 	char *help;
@@ -105,16 +105,16 @@ void commands_fsl_imx_init(void);
  * "unnecessary" pointer comparison.
  */
 #define min(x, y) ({                            \
-        typeof(x) _min1 = (x);                  \
-        typeof(y) _min2 = (y);                  \
-        (void) (&_min1 == &_min2);              \
-        _min1 < _min2 ? _min1 : _min2; })
+		typeof(x) _min1 = (x);                  \
+		typeof(y) _min2 = (y);                  \
+		(void)(&_min1 == &_min2);              \
+		_min1 < _min2 ? _min1 : _min2; })
 
 #define max(x, y) ({                            \
-        typeof(x) _max1 = (x);                  \
-        typeof(y) _max2 = (y);                  \
-        (void) (&_max1 == &_max2);              \
-        _max1 > _max2 ? _max1 : _max2; })
+		typeof(x) _max1 = (x);                  \
+		typeof(y) _max2 = (y);                  \
+		(void)(&_max1 == &_max2);              \
+		_max1 > _max2 ? _max1 : _max2; })
 
 extern unsigned long current_speed;
 extern int current_flow;
@@ -128,36 +128,36 @@ int do_script(char *script);
  * https://www.iana.org/assignments/telnet-options/telnet-options.xhtmls
  */
 
-#define TELNET_OPTION_BINARY_TRANSMISSION		0
-#define TELNET_OPTION_ECHO				1
-#define TELNET_OPTION_SUPPRESS_GO_AHEAD			3
-#define TELNET_OPTION_COM_PORT_CONTROL			44
+#define TELNET_OPTION_BINARY_TRANSMISSION               0
+#define TELNET_OPTION_ECHO                              1
+#define TELNET_OPTION_SUPPRESS_GO_AHEAD                 3
+#define TELNET_OPTION_COM_PORT_CONTROL                  44
 
 /* RFC2217 */
-#define SET_BAUDRATE_CS		  1
-#define SET_DATASIZE_CS		  2
-#define SET_PARITY_CS		  3
-#define SET_STOPSIZE_CS		  4
-#define SET_CONTROL_CS		  5
-#define NOTIFY_LINESTATE_CS	  6
-#define NOTIFY_MODEMSTATE_CS	  7
-#define FLOWCONTROL_SUSPEND_CS	  8
-#define FLOWCONTROL_RESUME_CS	  9
-#define SET_LINESTATE_MASK_CS	 10
-#define SET_MODEMSTATE_MASK_CS	 11
-#define PURGE_DATA_CS		 12
-#define SET_BAUDRATE_SC		101
-#define SET_DATASIZE_SC		102
-#define SET_PARITY_SC		103
-#define SET_STOPSIZE_SC		104
-#define SET_CONTROL_SC		105
-#define NOTIFY_LINESTATE_SC	106
-#define NOTIFY_MODEMSTATE_SC	107
-#define FLOWCONTROL_SUSPEND_SC	108
-#define FLOWCONTROL_RESUME_SC	109
-#define SET_LINESTATE_MASK_SC	110
-#define SET_MODEMSTATE_MASK_SC	111
-#define PURGE_DATA_SC		112
+#define SET_BAUDRATE_CS           1
+#define SET_DATASIZE_CS           2
+#define SET_PARITY_CS             3
+#define SET_STOPSIZE_CS           4
+#define SET_CONTROL_CS            5
+#define NOTIFY_LINESTATE_CS       6
+#define NOTIFY_MODEMSTATE_CS      7
+#define FLOWCONTROL_SUSPEND_CS    8
+#define FLOWCONTROL_RESUME_CS     9
+#define SET_LINESTATE_MASK_CS    10
+#define SET_MODEMSTATE_MASK_CS   11
+#define PURGE_DATA_CS            12
+#define SET_BAUDRATE_SC         101
+#define SET_DATASIZE_SC         102
+#define SET_PARITY_SC           103
+#define SET_STOPSIZE_SC         104
+#define SET_CONTROL_SC          105
+#define NOTIFY_LINESTATE_SC     106
+#define NOTIFY_MODEMSTATE_SC    107
+#define FLOWCONTROL_SUSPEND_SC  108
+#define FLOWCONTROL_RESUME_SC   109
+#define SET_LINESTATE_MASK_SC   110
+#define SET_MODEMSTATE_MASK_SC  111
+#define PURGE_DATA_SC           112
 
 #endif /* MICROCOM_H */
 

--- a/microcom.h
+++ b/microcom.h
@@ -41,8 +41,8 @@
 #define DEFAULT_ESCAPE_CHAR ('\\')
 
 struct ios_ops {
-	ssize_t (*write)(struct ios_ops *, const void *buf, size_t count);
-	ssize_t (*read)(struct ios_ops *, void *buf, size_t count);
+	ssize_t (*write)(struct ios_ops *, const unsigned char *buf, size_t count);
+	ssize_t (*read)(struct ios_ops *, unsigned char *buf, size_t count);
 	int (*set_speed)(struct ios_ops *, unsigned long speed);
 #define FLOW_NONE	0
 #define FLOW_SOFT	1

--- a/microcom.h
+++ b/microcom.h
@@ -121,7 +121,7 @@ extern int current_flow;
 int do_commandline(void);
 int do_script(char *script);
 
-#define dbg_printf(fmt,args...)  ({ if (debug) printf(fmt ,##args); })
+#define dbg_printf(...) ({ if (debug) printf(__VA_ARGS__); })
 
 /*
  * Some telnet options according to

--- a/mux.c
+++ b/mux.c
@@ -53,7 +53,7 @@ static void cook_buf(struct ios_ops *ios, unsigned char *buf, int num)
 {
 	int current = 0;
 
-	while (current < num) {	/* big while loop, to process all the charactes in buffer */
+	while (current < num) { /* big while loop, to process all the charactes in buffer */
 
 		/* look for the next escape character (Ctrl-\) */
 		while ((current < num) && (buf[current] != CTRL(escape_char)))
@@ -62,15 +62,15 @@ static void cook_buf(struct ios_ops *ios, unsigned char *buf, int num)
 		if (current)
 			ios->write(ios, buf, current);
 
-		if (current < num) {	/* process an escape sequence */
+		if (current < num) { /* process an escape sequence */
 			/* found an escape character */
 			do_commandline();
 			return;
-		}		/* if - end of processing escape sequence */
+		}                    /* if - end of processing escape sequence */
 		num -= current;
 		buf += current;
 		current = 0;
-	}			/* while - end of processing all the charactes in the buffer */
+	}                       /* while - end of processing all the charactes in the buffer */
 }
 
 void logfile_close(void)
@@ -102,8 +102,8 @@ int logfile_open(const char *path)
 /* main program loop */
 int mux_loop(struct ios_ops *ios)
 {
-	fd_set ready;		/* used for select */
-	int i = 0, len;		/* used in the multiplex loop */
+	fd_set ready;   /* used for select */
+	int i = 0, len; /* used in the multiplex loop */
 	unsigned char buf[BUFSIZE];
 
 	while (1) {

--- a/mux.c
+++ b/mux.c
@@ -28,10 +28,12 @@ static int handle_receive_buf(struct ios_ops *ios, unsigned char *buf, int len)
 		switch (*buf) {
 		case 5:
 			write_receive_buf(sendbuf, buf - sendbuf);
-			if (answerback)
+			if (answerback) {
 				ios->write(ios, answerback, strlen(answerback));
-			else
+				ios->write(ios, "\n", 1);
+			} else {
 				write_receive_buf(buf, 1);
+			}
 
 			buf += 1;
 			len -= 1;

--- a/mux.c
+++ b/mux.c
@@ -1,22 +1,5 @@
-/***************************************************************************
-** File: mux.c
-** Description: the main program loop
-**
-** Copyright (C)1999 Anca and Lucian Jurubita <ljurubita@hotmail.com>.
-** All rights reserved.
-****************************************************************************
-** This program is free software; you can redistribute it and/or
-** modify it under the terms of the GNU General Public License
-** as published by the Free Software Foundation; either version 2
-** of the License, or (at your option) any later version.
-**
-** This program is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-** GNU General Public License for more details at www.gnu.org
-****************************************************************************
-** Rev. 1.0 - Feb. 2000
-****************************************************************************/
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999 Anca and Lucian Jurubita <ljurubita@hotmail.com>.
 #include "config.h"
 
 #include "microcom.h"

--- a/parser.c
+++ b/parser.c
@@ -57,7 +57,7 @@ static int parse_line(char *_line, int *argc, char *argv[])
 		*line++ = '\0';         /* terminate current arg         */
 	}
 
-        printf("Too many args (max. %d)\n", MAXARGS);
+	printf("Too many args (max. %d)\n", MAXARGS);
 out:
 	argv[nargs] = NULL;
 	*argc = nargs;
@@ -75,7 +75,7 @@ int register_command(struct cmd *cmd)
 
 	if (!commands) {
 		commands = cmd;
-		return 0;		
+		return 0;
 	}
 
 	tmp = commands;

--- a/parser.c
+++ b/parser.c
@@ -1,11 +1,5 @@
-/*
- * Copyright (C) 2010 Sascha Hauer <s.hauer@pengutronix.de>
- *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
- */
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 2010 Sascha Hauer <s.hauer@pengutronix.de>
 #include "config.h"
 
 #include <stdio.h>

--- a/serial.c
+++ b/serial.c
@@ -9,7 +9,7 @@
 
 #include "microcom.h"
 
-static struct termios pots;		/* old port termios settings to restore */
+static struct termios pots; /* old port termios settings to restore */
 
 static void init_comm(struct termios *pts)
 {
@@ -74,51 +74,51 @@ static const struct {
 	{ 200, B200 },
 	{ 300, B300 },
 	{ 600, B600 },
-	{ 1200, B1200},
-	{ 1800, B1800},
-	{ 2400, B2400},
-	{ 4800, B4800},
-	{ 9600, B9600},
-	{ 19200, B19200},
-	{ 38400, B38400},
-	{ 57600, B57600},
-	{ 115200, B115200},
-	{ 230400, B230400},
+	{ 1200, B1200 },
+	{ 1800, B1800 },
+	{ 2400, B2400 },
+	{ 4800, B4800 },
+	{ 9600, B9600 },
+	{ 19200, B19200 },
+	{ 38400, B38400 },
+	{ 57600, B57600 },
+	{ 115200, B115200 },
+	{ 230400, B230400 },
 #ifdef B460800
-	{ 460800, B460800},
+	{ 460800, B460800 },
 #endif
 #ifdef B500000
-	{ 500000, B500000},
+	{ 500000, B500000 },
 #endif
 #ifdef B576000
-	{ 576000, B576000},
+	{ 576000, B576000 },
 #endif
 #ifdef B921600
-	{ 921600, B921600},
+	{ 921600, B921600 },
 #endif
 #ifdef B1000000
-	{ 1000000, B1000000},
+	{ 1000000, B1000000 },
 #endif
 #ifdef B1152000
-	{ 1152000, B1152000},
+	{ 1152000, B1152000 },
 #endif
 #ifdef B1500000
-	{ 1500000, B1500000},
+	{ 1500000, B1500000 },
 #endif
 #ifdef B2000000
-	{ 2000000, B2000000},
+	{ 2000000, B2000000 },
 #endif
 #ifdef B2500000
-	{ 2500000, B2500000},
+	{ 2500000, B2500000 },
 #endif
 #ifdef B3000000
-	{ 3000000, B3000000},
+	{ 3000000, B3000000 },
 #endif
 #ifdef B3500000
-	{ 3500000, B3500000},
+	{ 3500000, B3500000 },
 #endif
 #ifdef B4000000
-	{ 4000000, B4000000},
+	{ 4000000, B4000000 },
 #endif
 };
 
@@ -138,7 +138,7 @@ static int baudrate_to_flag(int speed, speed_t *flag)
 
 static int serial_set_speed(struct ios_ops *ios, unsigned long speed)
 {
-	struct termios pts;	/* termios settings on port */
+	struct termios pts; /* termios settings on port */
 	speed_t flag;
 	int ret;
 
@@ -157,7 +157,8 @@ static int serial_set_speed(struct ios_ops *ios, unsigned long speed)
 
 static int serial_set_flow(struct ios_ops *ios, int flow)
 {
-	struct termios pts;	/* termios settings on port */
+	struct termios pts; /* termios settings on port */
+
 	tcgetattr(ios->fd, &pts);
 
 	switch (flow) {
@@ -210,7 +211,7 @@ static void serial_exit(struct ios_ops *ios)
 
 struct ios_ops * serial_init(char *device)
 {
-	struct termios pts;	/* termios settings on port */
+	struct termios pts; /* termios settings on port */
 	struct ios_ops *ops;
 	int fd, ret;
 
@@ -244,7 +245,7 @@ struct ios_ops * serial_init(char *device)
 
 	/* modify the port configuration */
 	tcgetattr(fd, &pts);
-	memcpy(&pots, &pts, sizeof (pots));
+	memcpy(&pots, &pts, sizeof(pots));
 	init_comm(&pts);
 	tcsetattr(fd, TCSANOW, &pts);
 	printf("connected to %s\n", device);

--- a/serial.c
+++ b/serial.c
@@ -1,24 +1,5 @@
-/******************************************************************
-** File: serial.c
-** Description: the serial part for microcom project
-**
-** Copyright (C)1999 Anca and Lucian Jurubita <ljurubita@hotmail.com>.
-** All rights reserved.
-****************************************************************************
-** This program is free software; you can redistribute it and/or
-** modify it under the terms of the GNU General Public License
-** as published by the Free Software Foundation; either version 2
-** of the License, or (at your option) any later version.
-**
-** This program is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-** GNU General Public License for more details at www.gnu.org
-****************************************************************************
-** Rev. 1.0 - Feb. 2000
-** Rev. 1.01 - March 2000
-** Rev. 1.02 - June 2000
-****************************************************************************/
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 1999 Anca and Lucian Jurubita <ljurubita@hotmail.com>.
 #include "config.h"
 
 #include <limits.h>

--- a/serial.c
+++ b/serial.c
@@ -49,12 +49,12 @@ static void init_comm(struct termios *pts)
 	pts->c_iflag &= ~ICRNL;
 }
 
-static ssize_t serial_write(struct ios_ops *ios, const void *buf, size_t count)
+static ssize_t serial_write(struct ios_ops *ios, const unsigned char *buf, size_t count)
 {
 	return write(ios->fd, buf, count);
 }
 
-static ssize_t serial_read(struct ios_ops *ios, void *buf, size_t count)
+static ssize_t serial_read(struct ios_ops *ios, unsigned char *buf, size_t count)
 {
 	return read(ios->fd, buf, count);
 }

--- a/telnet.c
+++ b/telnet.c
@@ -130,18 +130,18 @@ static int do_com_port_option(struct ios_ops *ios, unsigned char *buf, int len)
 		dbg_printf("PURGE_DATA_CS ");
 		break;
 	case SET_BAUDRATE_SC:
-		{
-			uint32_t baudrate;
-			ssize_t getres = getl(buf + 2, &baudrate, len - 2);
+	{
+		uint32_t baudrate;
+		ssize_t getres = getl(buf + 2, &baudrate, len - 2);
 
-			if (getres < 0) {
-				fprintf(stderr, "Incomplete or broken SB (SET_BAUDRATE_SC)\n");
-				return getres;
-			}
-			dbg_printf("SET_BAUDRATE_SC %u ", baudrate);
-			i += getres;;
+		if (getres < 0) {
+			fprintf(stderr, "Incomplete or broken SB (SET_BAUDRATE_SC)\n");
+			return getres;
 		}
-		break;
+		dbg_printf("SET_BAUDRATE_SC %u ", baudrate);
+		i += getres;;
+	}
+	break;
 	case SET_DATASIZE_SC:
 		dbg_printf("SET_DATASIZE_SC ");
 		break;
@@ -152,35 +152,35 @@ static int do_com_port_option(struct ios_ops *ios, unsigned char *buf, int len)
 		dbg_printf("SET_STOPSIZE_SC ");
 		break;
 	case SET_CONTROL_SC:
-		{
-			unsigned char ctrl;
-			ssize_t getres = get(buf + 2, &ctrl, len - 2);
+	{
+		unsigned char ctrl;
+		ssize_t getres = get(buf + 2, &ctrl, len - 2);
 
-			if (getres < 0) {
-				fprintf(stderr, "Incomplete or broken SB (SET_CONTROL_SC)\n");
-				return getres;
-			}
-
-			dbg_printf("SET_CONTROL_SC 0x%02x ", ctrl);
-			i += getres;
+		if (getres < 0) {
+			fprintf(stderr, "Incomplete or broken SB (SET_CONTROL_SC)\n");
+			return getres;
 		}
-		break;
+
+		dbg_printf("SET_CONTROL_SC 0x%02x ", ctrl);
+		i += getres;
+	}
+	break;
 	case NOTIFY_LINESTATE_SC:
 		dbg_printf("NOTIFY_LINESTATE_SC ");
 		break;
 	case NOTIFY_MODEMSTATE_SC:
-		{
-			unsigned char ms;
-			ssize_t getres = get(buf + 2, &ms, len - 2);
+	{
+		unsigned char ms;
+		ssize_t getres = get(buf + 2, &ms, len - 2);
 
-			if (getres < 0) {
-				fprintf(stderr, "Incomplete or broken SB (NOTIFY_MODEMSTATE_SC)\n");
-				return getres;
-			}
-
-			dbg_printf("NOTIFY_MODEMSTATE_SC 0x%02x ", ms);
-			i += getres;
+		if (getres < 0) {
+			fprintf(stderr, "Incomplete or broken SB (NOTIFY_MODEMSTATE_SC)\n");
+			return getres;
 		}
+
+		dbg_printf("NOTIFY_MODEMSTATE_SC 0x%02x ", ms);
+		i += getres;
+	}
 	case FLOWCONTROL_SUSPEND_SC:
 		dbg_printf("FLOWCONTROL_SUSPEND_SC ");
 		break;
@@ -203,10 +203,10 @@ static int do_com_port_option(struct ios_ops *ios, unsigned char *buf, int len)
 
 	while (i < len) {
 		if (buf[i] == IAC) {
-			if (i + 1 < len && buf[i+1] == IAC) {
+			if (i + 1 < len && buf[i + 1] == IAC) {
 				/* quoted IAC -> unquote */
 				++i;
-			} else if (i + 1 < len && buf[i+1] == SE) {
+			} else if (i + 1 < len && buf[i + 1] == SE) {
 				dbg_printf("IAC SE\n");
 				return i + 2;
 			}
@@ -234,7 +234,7 @@ struct telnet_option {
 	bool sent_will;
 };
 
-#define TELNET_OPTION(x)	.id = TELNET_OPTION_ ## x, .name = #x
+#define TELNET_OPTION(x)        .id = TELNET_OPTION_ ## x, .name = #x
 
 static const struct telnet_option telnet_options[] = {
 	{
@@ -420,6 +420,8 @@ static ssize_t telnet_read(struct ios_ops *ios, unsigned char *buf, size_t count
 	unsigned char *iac;
 	size_t handled = 0;
 
+	ret = read(ios->fd, buf, count);
+
 	if (ret <= 0)
 		return ret;
 
@@ -452,7 +454,7 @@ static ssize_t telnet_read(struct ios_ops *ios, unsigned char *buf, size_t count
 
 static int telnet_set_speed(struct ios_ops *ios, unsigned long speed)
 {
-	unsigned char buf2[14] = {IAC, SB, TELNET_OPTION_COM_PORT_CONTROL, SET_BAUDRATE_CS};
+	unsigned char buf2[14] = { IAC, SB, TELNET_OPTION_COM_PORT_CONTROL, SET_BAUDRATE_CS };
 	size_t offset = 4;
 	int i;
 
@@ -473,7 +475,7 @@ static int telnet_set_speed(struct ios_ops *ios, unsigned long speed)
 
 static int telnet_set_flow(struct ios_ops *ios, int flow)
 {
-	unsigned char buf2[] = {IAC, SB, TELNET_OPTION_COM_PORT_CONTROL, SET_CONTROL_CS, 0, IAC, SE};
+	unsigned char buf2[] = { IAC, SB, TELNET_OPTION_COM_PORT_CONTROL, SET_CONTROL_CS, 0, IAC, SE };
 
 	switch (flow) {
 	case FLOW_NONE:
@@ -498,7 +500,7 @@ static int telnet_set_flow(struct ios_ops *ios, int flow)
 
 static int telnet_send_break(struct ios_ops *ios)
 {
-	unsigned char buf2[] = {IAC, BREAK};
+	unsigned char buf2[] = { IAC, BREAK };
 
 	write(ios->fd, buf2, sizeof(buf2));
 

--- a/telnet.c
+++ b/telnet.c
@@ -398,11 +398,11 @@ static int handle_command(struct ios_ops *ios, unsigned char *buf, int len)
 	}
 }
 
-static ssize_t telnet_write(struct ios_ops *ios, const void *buf, size_t count)
+static ssize_t telnet_write(struct ios_ops *ios, const unsigned char *buf, size_t count)
 {
 	size_t handled = 0;
 	ssize_t ret;
-	void *iac;
+	unsigned char *iac;
 
 	/*
 	 * To send an IAC character in the data stream, two IACs must be sent.
@@ -429,10 +429,10 @@ static ssize_t telnet_write(struct ios_ops *ios, const void *buf, size_t count)
 	return ret + handled;
 }
 
-static ssize_t telnet_read(struct ios_ops *ios, void *buf, size_t count)
+static ssize_t telnet_read(struct ios_ops *ios, unsigned char *buf, size_t count)
 {
-	ssize_t ret = read(ios->fd, buf, count);
-	void *iac;
+	ssize_t ret;
+	unsigned char *iac;
 	size_t handled = 0;
 
 	if (ret <= 0)

--- a/telnet.c
+++ b/telnet.c
@@ -1,20 +1,5 @@
-/******************************************************************
-** File: telnet.c
-** Description: the telnet part for microcom project
-**
-** Copyright (C) 2008, 2009 Sascha Hauer <s.hauer@pengutronix.de>.
-** All rights reserved.
-****************************************************************************
-** This program is free software; you can redistribute it and/or
-** modify it under the terms of the GNU General Public License
-** as published by the Free Software Foundation; either version 2
-** of the License, or (at your option) any later version.
-**
-** This program is distributed in the hope that it will be useful,
-** but WITHOUT ANY WARRANTY; without even the implied warranty of
-** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-** GNU General Public License for more details at www.gnu.org
-****************************************************************************/
+// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-FileCopyrightText: 2008, 2009 Sascha Hauer <s.hauer@pengutronix.de>
 #include "config.h"
 
 #include <stdlib.h>

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,0 +1,92 @@
+#
+# uncrustify config file based on https://uncrustify.sourceforge.net/linux.cfg.txt
+#
+
+indent_with_tabs             = 2             # 1=indent to level only, 2=indent with tabs
+input_tab_size               = 8             # original tab size
+output_tab_size              = 8             # new tab size
+indent_columns               = output_tab_size
+
+indent_label                 = 1             # pos: absolute col, neg: relative column
+
+
+#
+# inter-symbol newlines
+#
+
+nl_enum_brace                = remove        # "enum {" vs "enum \n {"
+nl_union_brace               = remove        # "union {" vs "union \n {"
+nl_struct_brace              = remove        # "struct {" vs "struct \n {"
+nl_do_brace                  = remove        # "do {" vs "do \n {"
+nl_if_brace                  = remove        # "if () {" vs "if () \n {"
+nl_for_brace                 = remove        # "for () {" vs "for () \n {"
+nl_else_brace                = remove        # "else {" vs "else \n {"
+nl_while_brace               = remove        # "while () {" vs "while () \n {"
+nl_switch_brace              = remove        # "switch () {" vs "switch () \n {"
+nl_brace_while               = remove        # "} while" vs "} \n while" - cuddle while
+nl_brace_else                = remove        # "} else" vs "} \n else" - cuddle else
+nl_var_def_blk_end_func_top  = 1
+nl_fcall_brace               = remove        # "list_for_each() {" vs "list_for_each()\n{"
+nl_fdef_brace                = add           # "int foo() {" vs "int foo()\n{"
+# nl_after_return            = TRUE;
+# nl_before_case             = 1
+
+
+#
+# Source code modifications
+#
+
+mod_paren_on_return          = remove        # "return 1;" vs "return (1);"
+#mod_full_brace_if           = remove        # "if (a) a--;" vs "if (a) { a--; }"
+#mod_full_brace_for          = remove        # "for () a--;" vs "for () { a--; }"
+#mod_full_brace_do           = remove        # "do a--; while ();" vs "do { a--; } while ();"
+#mod_full_brace_while        = remove        # "while (a) a--;" vs "while (a) { a--; }"
+#mod_full_brace_nl           = 3             # don't remove if more than 3 newlines
+
+
+#
+# inter-character spacing options
+#
+
+# sp_return_paren            = force         # "return (1);" vs "return(1);"
+sp_sizeof_paren              = remove        # "sizeof (int)" vs "sizeof(int)"
+sp_before_sparen             = force         # "if (" vs "if("
+sp_after_sparen              = force         # "if () {" vs "if (){"
+sp_after_cast                = remove        # "(int) a" vs "(int)a"
+sp_inside_braces            = add           # "{ 1 }" vs "{1}"
+sp_inside_braces_struct     = add           # "{ 1 }" vs "{1}"
+sp_inside_braces_enum       = add           # "{ 1 }" vs "{1}"
+sp_assign                    = add
+sp_arith                     = add
+sp_bool                      = add
+sp_compare                   = add
+sp_assign                    = add
+sp_after_comma             = add
+sp_func_def_paren            = remove        # "int foo (){" vs "int foo(){"
+sp_func_call_paren           = remove        # "foo (" vs "foo("
+sp_func_proto_paren          = remove        # "int foo ();" vs "int foo();"
+
+
+#
+# Aligning stuff
+#
+
+align_with_tabs              = TRUE          # use tabs to align
+align_on_tabstop             = TRUE          # align on tabstops
+# align_keep_tabs            = true
+align_enum_equ_span          = 4             # '=' in enum definition
+# align_nl_cont              = 1
+# align_var_def_span         = 2
+# align_var_def_inline       = TRUE
+# align_var_def_star         = FALSE
+# align_var_def_colon        = TRUE
+# align_assign_span          = 1
+#align_struct_init_span      = 3             # align stuff in a structure init '= { }'
+#align_right_cmt_span        = 3
+# align_pp_define_span       = 8;
+# align_pp_define_gap        = 4;
+
+# cmt_star_cont              = FALSE
+
+# indent_brace               = 0
+


### PR DESCRIPTION
This pr contains a series of housekeeping patches.

Dropping a single unused `int i` is probably uncontroversial, removing lengthy license headers in favor of two SPDX lines and broad code reformatting maybe less so.

Changes where made to now pass most of `-Wpedantic`, where adaption seemed appropriate.

I used uncrustify to enforce some basic code style rules, and added the uncrustify config to version control. The chosen ruleset is very soft and tries to be close to kernel style. I only enabled uncrustify rules where I found all changes it lead to in the current codebase to be beneficial in every single instance.