### PR TITLE
microcom.c: Call cleanup routines only once

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -144,7 +144,6 @@ static int cmd_break(int argc, char *argv[])
 static int cmd_quit(int argc, char *argv[])
 {
 	fflush(NULL);
-	microcom_exit(0);
 	exit(0);
 	return 0;
 }

--- a/microcom.c
+++ b/microcom.c
@@ -20,6 +20,12 @@ struct ios_ops *ios;
 int debug = 0;
 int quiet = 0;
 
+int opt_force = 0;
+unsigned long current_speed = DEFAULT_BAUDRATE;
+int current_flow = FLOW_NONE;
+int listenonly = 0;
+char escape_char = DEFAULT_ESCAPE_CHAR;
+
 void init_terminal(void)
 {
 	struct termios sts;
@@ -47,15 +53,25 @@ void restore_terminal(void)
 }
 
 
-void microcom_exit(int signal)
+static void microcom_exit(int signal)
 {
-	write(1, "exiting\n", 8);
+	static const char exit_msg[] = "exiting\n";
+
+	if (write(STDOUT_FILENO, exit_msg, sizeof(exit_msg) - 1) < 0) {
+		/* couldn't write message but already exiting */
+	}
 
 	ios->exit(ios);
-	tcsetattr(STDIN_FILENO, TCSANOW, &sots);
+	if (!listenonly)
+		tcsetattr(STDIN_FILENO, TCSANOW, &sots);
 
 	if (signal)
 		_Exit(0);
+}
+
+static void atexit_cleanup(void)
+{
+	microcom_exit(0);
 }
 
 /*
@@ -97,12 +113,6 @@ void main_usage(int exitcode, char *str, char *dev)
 	fprintf(stderr, "Exitcode %d - %s %s\n\n", exitcode, str, dev);
 	exit(exitcode);
 }
-
-int opt_force = 0;
-unsigned long current_speed = DEFAULT_BAUDRATE;
-int current_flow = FLOW_NONE;
-int listenonly = 0;
-char escape_char = DEFAULT_ESCAPE_CHAR;
 
 int main(int argc, char *argv[])
 {
@@ -216,7 +226,7 @@ int main(int argc, char *argv[])
 
 	ret = ios->set_speed(ios, current_speed);
 	if (ret)
-		goto cleanup_ios;
+		exit(1);
 
 	current_flow = FLOW_NONE;
 	ios->set_flow(ios, current_flow);
@@ -226,27 +236,23 @@ int main(int argc, char *argv[])
 		msg_printf("Type the escape character to get to the prompt.\n");
 
 		/* Now deal with the local terminal side */
+		/*  microcom_exit will restore the old termios handler */
 		tcgetattr(STDIN_FILENO, &sots);
 		init_terminal();
-
-		/* set the signal handler to restore the old
-		 * termios handler */
-		sact.sa_handler = &microcom_exit;
-		sigaction(SIGHUP, &sact, NULL);
-		sigaction(SIGINT, &sact, NULL);
-		sigaction(SIGPIPE, &sact, NULL);
-		sigaction(SIGTERM, &sact, NULL);
-		sigaction(SIGQUIT, &sact, NULL);
 	}
+
+	sact.sa_handler = &microcom_exit;
+
+	sigaction(SIGHUP, &sact, NULL);
+	sigaction(SIGINT, &sact, NULL);
+	sigaction(SIGPIPE, &sact, NULL);
+	sigaction(SIGTERM, &sact, NULL);
+	sigaction(SIGQUIT, &sact, NULL);
+
+	atexit(atexit_cleanup);
 
 	/* run the main program loop */
 	ret = mux_loop(ios);
-
-	if (!listenonly)
-		tcsetattr(STDIN_FILENO, TCSANOW, &sots);
-
-cleanup_ios:
-	ios->exit(ios);
 
 	exit(ret ? 1 : 0);
 }

--- a/microcom.h
+++ b/microcom.h
@@ -64,8 +64,6 @@ struct ios_ops *telnet_init(char *hostport);
 struct ios_ops *serial_init(char *dev);
 struct ios_ops *can_init(char *interfaceid);
 
-void microcom_exit(int signal);
-
 void microcom_cmd_usage(char *str);
 
 void main_usage(int exitcode, char *str, char *dev);


### PR DESCRIPTION
Repeated call to ios->exit(ios); was observed as used after free using asan. Only call it once: In the exit handler.

Always call the exit handler and check there whether listenonly is set and there skip resetting the terminal if so.

Do not reset the terminal elsewhere.

Do not call the exit handler from the quit command, call exit instead.