### PR TITLE
Pytest tests and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,16 +12,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
 
       - name: Install Dependencies
-        run:
-          sudo apt install
-          libreadline6-dev
-          autoconf
-          automake
+        run: |
+          sudo apt update -y
+          sudo apt install -y \
+            libreadline6-dev \
+            autoconf \
+            automake \
+            python3-pytest
 
       - name: Prepare (autoreconf)
         run: autoreconf -i
@@ -32,8 +33,8 @@ jobs:
       - name: Build
         run: make
 
+      - name: Run pytest
+        run: pytest -v
+
       - name: Run check
         run: make check
-
-      - name: Run distcheck
-        run: make distcheck

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      C_WARN: "-Wall -Wextra -Wno-error=unused-result -Wno-pointer-sign -Wno-unused-parameter -Wno-sign-compare"
     steps:
       - uses: actions/checkout@v3
 
@@ -28,12 +30,18 @@ jobs:
         run: autoreconf -i
 
       - name: Prepare (configure)
+        env:
+          CFLAGS: "-g -O2 -fsanitize=address,undefined -fno-omit-frame-pointer -Werror ${{ env.C_WARN }}"
+          LDFLAGS: "-fsanitize=address,undefined"
         run: ./configure
 
       - name: Build
         run: make
 
       - name: Run pytest
+        env:
+          ASAN_OPTIONS: "detect_leaks=1"
+          UBSAN_OPTIONS: "print_stacktrace=1"
         run: pytest -v
 
       - name: Run check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,25 +24,61 @@ jobs:
             libreadline6-dev \
             autoconf \
             automake \
-            python3-pytest
+            python3-pytest \
+            valgrind
 
       - name: Prepare (autoreconf)
         run: autoreconf -i
 
-      - name: Prepare (configure)
+      # Build 1: ASAN
+      - name: Create ASAN build directory
+        run: mkdir -p build-asan
+
+      - name: Configure ASAN build
+        working-directory: build-asan
         env:
           CFLAGS: "-g -O2 -fsanitize=address,undefined -fno-omit-frame-pointer -Werror ${{ env.C_WARN }}"
           LDFLAGS: "-fsanitize=address,undefined"
-        run: ./configure
+        run: ../configure
 
-      - name: Build
+      - name: Build ASAN
+        working-directory: build-asan
         run: make
 
-      - name: Run pytest
+      - name: Run pytest with ASAN
+        continue-on-error: true
         env:
           ASAN_OPTIONS: "detect_leaks=1"
           UBSAN_OPTIONS: "print_stacktrace=1"
-        run: pytest -v
+        run: pytest -v --cmd="build-asan/microcom"
 
-      - name: Run check
+      - name: Run check with ASAN
+        continue-on-error: true
+        working-directory: build-asan
+        env:
+          ASAN_OPTIONS: "detect_leaks=1"
+          UBSAN_OPTIONS: "print_stacktrace=1"
+        run: make check
+
+      # Build 2: Valgrind
+      - name: Create unoptimized build directory
+        run: mkdir -p build-unopt
+
+      - name: Configure unoptimized build
+        working-directory: build-unopt
+        env:
+          CFLAGS: "-g -O0 -Werror ${{ env.C_WARN }}"
+        run: ../configure
+
+      - name: Build unoptimized
+        working-directory: build-unopt
+        run: make
+
+      - name: Run pytest with Valgrind
+        continue-on-error: true
+        run: pytest -v --cmd="valgrind --tool=memcheck --error-exitcode=99 --quiet build-unopt/microcom"
+
+      - name: Run check with Valgrind
+        continue-on-error: true
+        working-directory: build-unopt
         run: make check

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,28 @@
+name: Enforce coding style
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y \
+            uncrustify
+      - name: enforce style using uncrustify
+        # uncrustify cannot output a diff. To make sure this works when
+        # invoking CI locally (i.e. via act) and the worktree is dirty, run
+        # uncrustify in two passes:
+        # 1. check if rules are followed
+        # 2. produce a diff if not
+        run: |
+          uncrustify --check -c uncrustify.cfg *.c *.h ||
+          ( uncrustify -q --replace -c uncrustify.cfg *.c *.h;
+            git diff --exit-code )

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - uses: astral-sh/ruff-action@v3
+
       - name: Install Dependencies
         run: |
           sudo apt update -y
@@ -26,3 +28,7 @@ jobs:
           uncrustify --check -c uncrustify.cfg *.c *.h ||
           ( uncrustify -q --replace -c uncrustify.cfg *.c *.h;
             git diff --exit-code )
+
+      - name: enforce python style using ruff
+        run: |
+          ruff format --check --diff

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 /*.o
 /microcom
+*.pyc
 
 # autotools stuff
 /.deps

--- a/can.c
+++ b/can.c
@@ -169,8 +169,8 @@ struct ios_ops *can_init(char *interface_id)
 		return NULL;
 	}
 
-	printf("connected to %s (rx_id=%x, tx_id=%x)\n",
-	       interface, filter->can_id, data.can_id);
+	msg_printf("connected to %s (rx_id=%x, tx_id=%x)\n",
+		   interface, filter->can_id, data.can_id);
 
 	return ios;
 }

--- a/microcom.c
+++ b/microcom.c
@@ -18,6 +18,7 @@ static struct termios sots; /* old stdout/in termios settings to restore */
 
 struct ios_ops *ios;
 int debug = 0;
+int quiet = 0;
 
 void init_terminal(void)
 {
@@ -81,6 +82,7 @@ void main_usage(int exitcode, char *str, char *dev)
 		"                                         default: (%s:%x:%x)\n"
 		"    -f, --force                          ignore existing lock file\n"
 		"    -d, --debug                          output debugging info\n"
+		"    -q, --quiet                          do not print status information to stdout\n"
 		"    -l, --logfile=<logfile>              log output to <logfile>\n"
 		"    -o, --listenonly                     Do not modify local terminal, do not send input\n"
 		"                                         from stdin\n"
@@ -119,6 +121,7 @@ int main(int argc, char *argv[])
 		{ "telnet", required_argument, NULL, 't' },
 		{ "can", required_argument, NULL, 'c' },
 		{ "debug", no_argument, NULL, 'd' },
+		{ "quiet", no_argument, NULL, 'q' },
 		{ "force", no_argument, NULL, 'f' },
 		{ "logfile", required_argument, NULL, 'l' },
 		{ "listenonly", no_argument, NULL, 'o' },
@@ -127,7 +130,7 @@ int main(int argc, char *argv[])
 		{ 0 },
 	};
 
-	while ((opt = getopt_long(argc, argv, "hp:s:t:c:dfl:oi:a:e:v", long_options, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "hp:s:t:c:dqfl:oi:a:e:v", long_options, NULL)) != -1) {
 		switch (opt) {
 		case '?':
 			main_usage(1, "", "");
@@ -158,6 +161,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'd':
 			debug = 1;
+			break;
+		case 'q':
+			quiet = 1;
 			break;
 		case 'l':
 			logfile = optarg;
@@ -216,8 +222,8 @@ int main(int argc, char *argv[])
 	ios->set_flow(ios, current_flow);
 
 	if (!listenonly) {
-		printf("Escape character: Ctrl-%c\n", escape_char);
-		printf("Type the escape character to get to the prompt.\n");
+		msg_printf("Escape character: Ctrl-%c\n", escape_char);
+		msg_printf("Type the escape character to get to the prompt.\n");
 
 		/* Now deal with the local terminal side */
 		tcgetattr(STDIN_FILENO, &sots);

--- a/microcom.c
+++ b/microcom.c
@@ -106,7 +106,7 @@ char escape_char = DEFAULT_ESCAPE_CHAR;
 
 int main(int argc, char *argv[])
 {
-	struct sigaction sact = {0};  /* used to initialize the signal handler */
+	struct sigaction sact = { 0 };  /* used to initialize the signal handler */
 	int opt, ret;
 	char *hostport = NULL;
 	int telnet = 0, can = 0;

--- a/microcom.h
+++ b/microcom.h
@@ -72,6 +72,7 @@ void main_usage(int exitcode, char *str, char *dev);
 
 extern struct ios_ops *ios;
 extern int debug;
+extern int quiet;
 extern int opt_force;
 extern int listenonly;
 extern char *answerback;
@@ -122,6 +123,7 @@ int do_commandline(void);
 int do_script(char *script);
 
 #define dbg_printf(...) ({ if (debug) printf(__VA_ARGS__); })
+#define msg_printf(...) ({ if (!quiet) printf(__VA_ARGS__); })
 
 /*
  * Some telnet options according to

--- a/serial.c
+++ b/serial.c
@@ -248,7 +248,7 @@ struct ios_ops * serial_init(char *device)
 	memcpy(&pots, &pts, sizeof(pots));
 	init_comm(&pts);
 	tcsetattr(fd, TCSANOW, &pts);
-	printf("connected to %s\n", device);
+	msg_printf("connected to %s\n", device);
 
 	return ops;
 }

--- a/telnet.c
+++ b/telnet.c
@@ -370,7 +370,7 @@ struct ios_ops *telnet_init(char *hostport)
 			fprintf(stderr, "getnameinfo: %s\n", gai_strerror(ret));
 			goto out;
 		}
-		printf("connected to %s (port %s)\n", connected_host, connected_port);
+		msg_printf("connected to %s (port %s)\n", connected_host, connected_port);
 
 		/* send intent we WILL do COM_PORT stuff */
 		dbg_printf("-> WILL COM_PORT_CONTROL\n");

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,24 @@
+import os
+from pathlib import Path
+import shlex
+import pytest
+
+
+def pytest_sessionstart(session):
+    # run tests in toplevel directory always, not in test/
+    os.chdir(Path(__file__).resolve().parent.parent)
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--cmd",
+        action="store",
+        default="./microcom",
+        help="Command used to invoke microcom",
+    )
+
+
+@pytest.fixture(scope="session")
+def cmd(pytestconfig):
+    cmd = pytestconfig.getoption("--cmd")
+    return shlex.split(cmd)

--- a/test/test_telnet.py
+++ b/test/test_telnet.py
@@ -1,0 +1,106 @@
+import socket
+import threading
+import time
+import pytest
+import subprocess
+import os
+import pty
+
+RFC2217_CMD = bytes([255, 254, 44])  # RFC2217 IAC DONT COM-PORT-OPTION
+
+
+def make_pattern(length):
+    ascii_range = list(range(32, 127))
+    return bytes(ascii_range[i % len(ascii_range)] for i in range(length))
+
+
+@pytest.fixture
+def telnet_recv(cmd):
+    def _recv(buf, timeout=1):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        host, port = sock.getsockname()
+
+        def run():
+            conn, _ = sock.accept()
+            with conn:
+                conn.sendall(buf)
+                time.sleep(
+                    0.01
+                )  # sadly without this, microcom may miss the transmission
+                sock.close()
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+
+        telnet_cmd = cmd + [f"--telnet={host}:{port}", "--quiet"]
+        master_fd, slave_fd = pty.openpty()
+        proc = subprocess.Popen(
+            telnet_cmd,
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=os.dup(2),
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        output = bytearray()
+        start_time = time.time()
+        while (time.time() - start_time) < timeout:
+            try:
+                chunk = os.read(master_fd, 1024)
+                if not chunk:
+                    break
+                output.extend(chunk)
+            except OSError:
+                break
+        os.close(master_fd)
+        proc.wait()
+        assert proc.returncode in (0, 1), (
+            f"Exit code must be 0 or 1, got {proc.returncode}"
+        )
+
+        return bytes(output)
+
+    return _recv
+
+
+@pytest.mark.parametrize("length", [10, 1023, 1024, 1025, 4000])
+def test_no_cmd(telnet_recv, length):
+    payload = make_pattern(length)
+
+    assert telnet_recv(payload) == payload
+
+
+def test_cmd_across_buffers(telnet_recv):
+    before_pattern = make_pattern(1023)
+    after_pattern = make_pattern(20)
+    payload = before_pattern + RFC2217_CMD + after_pattern
+    expected_output = before_pattern + after_pattern
+
+    assert telnet_recv(payload) == expected_output
+
+
+def test_cmd_buffer_end(telnet_recv):
+    pattern = make_pattern(1023)
+    payload = pattern + RFC2217_CMD
+
+    assert telnet_recv(payload) == pattern
+
+
+def test_cmd_within_buffer(telnet_recv):
+    before_pattern = make_pattern(345)
+    after_pattern = make_pattern(890)
+    payload = before_pattern + RFC2217_CMD + after_pattern
+    expected_output = before_pattern + after_pattern
+
+    assert telnet_recv(payload) == expected_output
+
+
+def test_iac_escape(telnet_recv):
+    before_pattern = make_pattern(42)
+    after_pattern = make_pattern(42)
+    payload = before_pattern + bytes([255, 255]) + after_pattern
+    expected_output = before_pattern + bytes([255]) + after_pattern
+
+    assert telnet_recv(payload) == expected_output


### PR DESCRIPTION
I've done some cleanup in the microcom codebase, and created a CI workflow to catch many of the encountered issues in the future.

These tests fail now, as long as the PRs resolving the issues are still open:

 - Pass many gcc diagnostics, follow some code style rules; see https://github.com/pengutronix/microcom/pull/55
 - Don't use uninitialized or freed memory, see https://github.com/pengutronix/microcom/pull/56
 - Don't access arrays out-of-bounds and test `telnet.c` to correctly handle command sequences at buffer boundaries, see https://github.com/pengutronix/microcom/pull/57