### PR TITLE
microcom: resolve missing non-POSIX stty settings

### DIFF
--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,7 @@
+/* POSIX-deprecated terminal settings, ignore if undefined */
+#ifndef IUCLC
+# define IUCLC 0
+#endif
+#ifndef XCASE
+# define XCASE 0
+#endif

--- a/microcom.c
+++ b/microcom.c
@@ -31,6 +31,7 @@
 #include <sys/stat.h>
 
 #include "config.h"
+#include "compat.h"
 
 static struct termios sots;	/* old stdout/in termios settings to restore */
 


### PR DESCRIPTION
`IUCLC` and `XCASE` have been reported to be missing on Mac OS (https://github.com/pengutronix/microcom/issues/59). As they've long been removed from POSIX, turn them into no-ops when unavailable.