### PR TITLE
parser: Hint how to exit commandline

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -209,7 +209,7 @@ static struct cmd cmds[] = {
 	}, {
 		.name = "exit",
 		.fn = cmd_exit,
-		.info = "exit from command processing",
+		.info = "exit from command processing and return to console",
 	}, {
 		.name = "flow",
 		.fn = cmd_flow,

--- a/parser.c
+++ b/parser.c
@@ -171,7 +171,7 @@ int do_commandline(void)
 	int ret;
 
 	restore_terminal();
-	printf("\nEnter command. Try \'help\' for a list of builtin commands\n");
+	printf("\nEnter command (try \'help\'). Press Ctrl+D to return to console.\n");
 
 	do {
 		ret = __do_commandline("-> ");


### PR DESCRIPTION
Document that Ctrl+D exits command processing and word it "return to console" to make clear that this does not exit microcom. Clarify the help text for the 'exit' command too.