### PR TITLE
Makefile.am: add missing compat.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,4 +11,4 @@ endif
 
 dist_man1_MANS = microcom.1
 
-noinst_HEADERS = microcom.h
+noinst_HEADERS = microcom.h compat.h


### PR DESCRIPTION
This was forgotten in commit a3d019940e10 ("microcom: resolve missing non-POSIX stty settings") and causes make distcheck to fail.