### PR TITLE
CI: Run on main branch push and PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,11 @@ name: Build test
 on:
   push:
     branches:
+      - main
       - master
   pull_request:
     branches:
+      - main
       - master
 
 jobs:


### PR DESCRIPTION
microcom has long had both a main and a (legacy) master branch. Fix CI by adding main to the branches to run on.

Keep master listed in case downstreams still use master as default branch.